### PR TITLE
[REFACTOR] 수신/발신 곡 조회 API 분리

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,14 +8,16 @@ datasource db {
 }
 
 model UserLikedArtist {
-  id         String   @id @unique @default(uuid())
-  createdAt  DateTime @default(now()) @map("created_at")
-  updatedAt  DateTime @updatedAt @map("updated_at")
-  artistId   String   @map("artist_id")
-  userId     String   @map("user_id")
-  artistName String   @map("artist_name")
-  imgUrl     String   @map("img_url")
-  user       User     @relation(fields: [userId], references: [id])
+  id              String       @id @unique @default(uuid())
+  createdAt       DateTime     @default(now()) @map("created_at")
+  updatedAt       DateTime     @updatedAt @map("updated_at")
+  artistId        String       @map("artist_id")
+  userId          String       @map("user_id")
+  artistName      String       @map("artist_name")
+  imgUrl          String       @map("img_url")
+  inactiveAt      DateTime?    @map("inactive_at")
+  inactiveStatus  Boolean      @default(false) @map("inactive_status")
+  user            User     @relation(fields: [userId], references: [id])
 }
 
 model Inquiry {
@@ -81,7 +83,7 @@ model User {
   socialType      SocialType        @map("social_type")
   nickname        String?           @db.VarChar(40)
   birth           DateTime?
-  gender          Gender            @default(MAN)
+  gender          Gender?           @default(MAN)
   photo           String?
   bio             String?
   createdAt       DateTime          @default(now()) @map("created_at")
@@ -100,6 +102,7 @@ model User {
   likedArtist     UserLikedArtist[]
   receivedRecoms  UserRecomsSong[]  @relation("UserReceivedRecom")
   sentRecoms      UserRecomsSong[]  @relation("UserSentRecom")
+  notifications   NotificationType?
 }
 
 model FcmToken {
@@ -119,6 +122,17 @@ model Session {
   @@map("session")
 }
 
+model NotificationType {
+  id              String     @id @unique @default(uuid())
+  userId          String     @map("user_id") @unique
+  recomsReceived  Boolean    @map("recoms_received") @default(true)
+  recomsSent      Boolean    @map("recoms_sent") @default(true)
+  commentArrived  Boolean    @map("comment_arrived") @default(true)
+  notRecoms       Boolean    @map("not_recoms") @default(true)
+  announcement    Boolean    @default(true)
+  user            User       @relation(fields: [userId], references: [id])
+}
+
 enum Gender {
   MAN
   WOMAN
@@ -131,9 +145,9 @@ enum SocialType {
 }
 
 enum NoticeType {
-  RECOMMEND_RECEIVED
-  RECOMMEND_SENT
-  RECOMMEND_UNREAD_TIMEOUT
-  RECOMMEND_READ_BY_OTHER
+  RECOMS_RECEIVED
+  RECOMS_SENT
+  COMMENT_ARRIVED
+  NOT_RECOMS
   ANNOUNCEMENT
 }

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -1,22 +1,41 @@
-export default {
-  responses: {
+export const responses = {
     Success: {
-      description: "성공 응답",
-      content: {
-        "application/json": {
-          schema: {
-            type: "object",
-            properties: {
-              success: { type: "boolean"},
-              data: { type: "object" },
-              error: {
-                type: ["object", "null"],
-                example: null
-              }
-            }
-          },
+        description: "성공 응답",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        success: { type: "boolean", example: true },
+                        data: { type: "object" },
+                        error: {
+                            type: ["object", "null"],
+                            example: null,
+                        },
+                    },
+                },
+            },
         },
-      },
-    },  
-  }
-}
+    },
+    Failed: {
+        description: "실패 응답",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        success: { type: "boolean", example: false },
+                        data: { type: "object" },
+                        error: {
+                            type: ["object", "null"],
+                            example: {
+                                code: "R1301",
+                                message: "에러 메시지",
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+};

--- a/src/dtos/recoms.dto.js
+++ b/src/dtos/recoms.dto.js
@@ -1,26 +1,47 @@
 export const searchTracksResponseDTO = (tracks) => {
     return {
-       data: tracks
-    }
-}
+        data: tracks,
+    };
+};
 
-export const trackInfoResponseDTO = (recomsData) => {
+export const sentRecomsResponseDTO = (recomsData) => {
     const kstDate = new Date(recomsData.createdAt.getTime() + 9 * 60 * 60 * 1000); // UTC+9 시간대
 
     return {
         id: recomsData.id,
         createdAt: kstDate.toISOString().slice(0, 10), // "YYYY-MM-DD"
-        isAnoymous: recomsData.isAnoymous,
-        isLiked: recomsData.isLiked,
-        recomsSong: recomsData.recomsSong,
-        sender: {
-            id: recomsData.sender.id,
-            nickname: recomsData.sender.nickname,
+        recomsSong: {
+            id: recomsData.recomsSong.id,
+            title: recomsData.recomsSong.title,
+            artistName: recomsData.recomsSong.artistName,
+            imgUrl: recomsData.recomsSong.imgUrl,
         },
         receiver: {
             id: recomsData.receiver.id,
             nickname: recomsData.receiver.nickname,
         },
-        replyId: recomsData.replies ? recomsData.replies.id : null,
+        replyId: recomsData.replies[0] ? recomsData.replies[0].id : null,
+    };
+};
+
+export const receivedRecomsResponseDTO = (recomsData) => {
+    const kstDate = new Date(recomsData.createdAt.getTime() + 9 * 60 * 60 * 1000); // UTC+9 시간대
+
+    return {
+        id: recomsData.id,
+        createdAt: kstDate.toISOString().slice(0, 10), // "YYYY-MM-DD",
+        isAnoymous: recomsData.isAnoymous,
+        isLiked: recomsData.isLiked,
+        recomsSong: {
+            id: recomsData.recomsSong.id,
+            title: recomsData.recomsSong.title,
+            artistName: recomsData.recomsSong.artistName,
+            imgUrl: recomsData.recomsSong.imgUrl,
+        },
+        sender: {
+            id: recomsData.sender.id,
+            nickname: recomsData.sender.nickname,
+        },
+        replyId: recomsData.replies[0] ? recomsData.replies[0].id : null,
     };
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,21 +1,21 @@
 export class MissingSearchQueryError extends Error {
-  errorCode = "RS1300";
+    errorCode = "RS1300";
 
-  constructor(reason = "검색어를 입력하세요.", data = null) {
-    super(reason);
-    this.reason = reason;
-    this.data = data;
-  }
+    constructor(reason = "검색어를 입력하세요.", data = null) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
 }
 
 export class RecommendationNotFoundError extends Error {
-  errorCode = "RS1301";
+    errorCode = "RS1301";
 
-  constructor(reason = "추천 기록이 존재하지 않습니다.", data = null) {
-    super(reason);
-    this.reason = reason;
-    this.data = data;
-  }
+    constructor(reason = "추천 기록이 존재하지 않습니다.", data = null) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
 }
 
 export class NotFoundUserEmail extends Error {
@@ -43,6 +43,17 @@ export class NotFoundKeyword extends Error {
 export class RecomsSongNotFoundError extends Error {
     errorCode = "R1301";
     statusCode = 404;
+
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
+export class UserMismatchError extends Error {
+    errorCode = "R1302";
+    statusCode = 403;
 
     constructor(reason, data) {
         super(reason);

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import session from "express-session";
 import passport from "passport";
 import { prisma } from "./configs/db.config.js";
 import { googleStrategy, naverStrategy, kakaoStrategy } from "./configs/auth.config.js";
+import { responses } from "./components/components.js";
 
 dotenv.config();
 
@@ -95,6 +96,16 @@ app.get("/openapi.json", async (req, res, next) => {
             description: "Bandnol 프로젝트의 API 명세입니다.",
         },
         host: "localhost:3000",
+        components: {
+            responses,
+            securitySchemes: {
+                bearerAuth: {
+                    type: "http",
+                    scheme: "bearer",
+                    bearerFormat: "JWT",
+                },
+            },
+        },
     };
 
     const result = await swaggerAutogen(options)(outputFile, routes, doc);

--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -1,19 +1,16 @@
 import { prisma } from "../configs/db.config.js";
 
-// 추천 곡 반환
-export const getRecomsSong = async (recomsId) => {
+// 발신한 추천 곡 반환
+export const getSentRecomsSong = async (recomsId) => {
     const recomsData = await prisma.userRecomsSong.findFirst({
         where: { id: recomsId },
         select: {
             id: true,
             createdAt: true,
-            isAnoymous: true,
-            isLiked: true,
             recomsSong: true,
             sender: {
                 select: {
                     id: true,
-                    nickname: true,
                 },
             },
             receiver: {
@@ -33,28 +30,57 @@ export const getRecomsSong = async (recomsId) => {
     return recomsData;
 };
 
+// 수신한 추천 곡 반환
+export const getReceivedRecomsSong = async (recomsId) => {
+    const recomsData = await prisma.userRecomsSong.findFirst({
+        where: { id: recomsId },
+        select: {
+            id: true,
+            createdAt: true,
+            isAnoymous: true,
+            isLiked: true,
+            recomsSong: true,
+            sender: {
+                select: {
+                    id: true,
+                    nickname: true,
+                },
+            },
+            receiver: {
+                select: {
+                    id: true,
+                },
+            },
+            replies: {
+                select: {
+                    id: true,
+                },
+            },
+        },
+    });
+
+    return recomsData;
+};
+
 export const findSongByKeyword = async (userId, keyword) => {
-  return await prisma.userRecomsSong.findMany({
-    where: {
-      AND: [
-        {
-          OR: [
-            { recomsSong: { title: { contains: keyword, mode: 'insensitive' } } },
-            { recomsSong: { artistName: { contains: keyword, mode: 'insensitive' } } },
-          ],
+    return await prisma.userRecomsSong.findMany({
+        where: {
+            AND: [
+                {
+                    OR: [
+                        { recomsSong: { title: { contains: keyword, mode: "insensitive" } } },
+                        { recomsSong: { artistName: { contains: keyword, mode: "insensitive" } } },
+                    ],
+                },
+                {
+                    OR: [{ senderId: userId }, { receiverId: userId }],
+                },
+            ],
         },
-        {
-          OR: [
-            { senderId: userId },
-            { receiverId: userId },
-          ],
+        include: {
+            recomsSong: true,
+            sender: { select: { id: true, nickname: true } },
+            receiver: { select: { id: true, nickname: true } },
         },
-      ],
-    },
-    include: {
-      recomsSong: true,
-      sender: { select: { id: true, nickname: true } },
-      receiver: { select: { id: true, nickname: true } },
-    },
-  });
+    });
 };

--- a/src/routes/recoms.router.js
+++ b/src/routes/recoms.router.js
@@ -1,15 +1,17 @@
 import { Router } from "express";
-
-import { handleAllTracks } from "../controllers/recoms.controller.js";
-import { handleRecomsSong } from "../controllers/recoms.controller.js";
-import { searchRecomSong } from "../controllers/recoms.controller.js";
-
+import {
+    handleAllTracks,
+    handleSentRecomsSong,
+    handleReceivedRecomsSong,
+    searchRecomSong,
+} from "../controllers/recoms.controller.js";
 import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
 
 const router = Router();
 
 router.get("/search-song", handleAllTracks);
-router.get("/recoms/:recomsId", authenticateAccessToken, handleRecomsSong);
+router.get("/:recomsId/sent", authenticateAccessToken, handleSentRecomsSong);
+router.get("/:recomsId/received", authenticateAccessToken, handleReceivedRecomsSong);
 router.get("/recoms/search/record", authenticateAccessToken, searchRecomSong);
 
 export default router;

--- a/src/services/recoms.service.js
+++ b/src/services/recoms.service.js
@@ -1,24 +1,41 @@
-import { trackInfoResponseDTO } from "../dtos/recoms.dto.js";
-import { RecomsSongNotFoundError } from "../errors.js";
-import { MissingSearchQueryError } from "../errors.js";
-import { getRecomsSong } from "../repositories/recoms.repository.js";
-import { findSongByKeyword } from "../repositories/recoms.repository.js";
+import { sentRecomsResponseDTO, receivedRecomsResponseDTO } from "../dtos/recoms.dto.js";
+import { RecomsSongNotFoundError, UserMismatchError, MissingSearchQueryError } from "../errors.js";
+import { getSentRecomsSong, getReceivedRecomsSong, findSongByKeyword } from "../repositories/recoms.repository.js";
 
-export const recomsSong = async (recomsId) => {
-    const recomsData = await getRecomsSong(recomsId);
+export const sentRecomsSong = async (recomsId, userId) => {
+    const recomsData = await getSentRecomsSong(recomsId);
 
-    if (recomsData === null) {
+    if (!recomsData) {
         throw new RecomsSongNotFoundError("해당 추천곡을 찾을 수 없습니다.");
     }
 
+    if (recomsData.sender.id !== userId) {
+        throw new UserMismatchError("본인이 발신한 추천 곡이 아닙니다. 조회 권한이 없습니다.");
+    }
+
     console.log(recomsData);
-    return trackInfoResponseDTO(recomsData);
+    return sentRecomsResponseDTO(recomsData);
+};
+
+export const receivedRecomsSong = async (recomsId, userId) => {
+    const recomsData = await getReceivedRecomsSong(recomsId);
+
+    if (!recomsData) {
+        throw new RecomsSongNotFoundError("해당 추천곡을 찾을 수 없습니다.");
+    }
+
+    if (recomsData.receiver.id !== userId) {
+        throw new UserMismatchError("본인이 수신한 추천 곡이 아닙니다. 조회 권한이 없습니다.");
+    }
+
+    console.log(recomsData);
+    return receivedRecomsResponseDTO(recomsData);
 };
 
 export const searchSong = async (userId, keyword) => {
-  if (!keyword) {
-    throw new MissingSearchQueryError();
-  }
+    if (!keyword) {
+        throw new MissingSearchQueryError();
+    }
 
-  return await findSongByKeyword(userId, keyword);
+    return await findSongByKeyword(userId, keyword);
 };


### PR DESCRIPTION
## 이슈번호 #21

### 📌 작업한 내용  
- 수신/발신 곡 조회 API 분리
- swagger 문서에 authorization header 등록하는 코드 추가
- swagger에 Failed component 추가

---


### 🔍 참고 사항  
- jwt token을 사용해야 하는 API의 swagger 문서에 아래 코드 추가해주시면 됩니다!
```
#swagger.security = [{
        bearerAuth: []
 }]
```

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [x] 로컬에서 빌드 및 테스트 완료  
- [x] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인
