### PR TITLE
[REFACTOR] 전체 응답 공통 양식 분리

### DIFF
--- a/src/components/components.js
+++ b/src/components/components.js
@@ -1,3 +1,5 @@
+import { NotSupportedSocialLoginError } from "../errors.js";
+
 export default {
   responses: {
     Success: {
@@ -9,6 +11,24 @@ export default {
             properties: {
               success: { type: "boolean", example: true },
               data: { type: "object" },
+              error: {
+                type: ["object", "null"],
+                example: null,
+              },
+            },
+          },
+        },
+      },
+    },
+    SuccessSocialLogin: {
+      description: "소셜 로그인 페이지로 리다이렉트합니다.",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: true },
+              data: { type: "object", nullable: true },
               error: {
                 type: ["object", "null"],
                 example: null,
@@ -172,5 +192,27 @@ export default {
         },
       },
     },
+    NotSupportedSocialLoginError: {
+        description: "소셜 로그인 실패했습니다. 인증 정보를 확인해주세요.",
+        content: {
+            "application/json": {
+                schema:{
+                    type: "object",
+                    properties: {
+                        success: { type: "boolean", example: false },
+                        data: {type: "object", nullable: true},
+                        error: {
+                            type: "object",
+                            properties: {
+                                errorCode: { type: "string" },
+                                reason: { type: "string" },
+                                data: { type: "object", nullable: true },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
   },
 };

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -1,41 +1,176 @@
-export const responses = {
+export default {
+  responses: {
     Success: {
-        description: "성공 응답",
-        content: {
-            "application/json": {
-                schema: {
-                    type: "object",
-                    properties: {
-                        success: { type: "boolean", example: true },
-                        data: { type: "object" },
-                        error: {
-                            type: ["object", "null"],
-                            example: null,
-                        },
-                    },
-                },
+      description: "성공 응답",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: true },
+              data: { type: "object" },
+              error: {
+                type: ["object", "null"],
+                example: null,
+              },
             },
+          },
         },
+      },
     },
-    Failed: {
-        description: "실패 응답",
-        content: {
-            "application/json": {
-                schema: {
-                    type: "object",
-                    properties: {
-                        success: { type: "boolean", example: false },
-                        data: { type: "object" },
-                        error: {
-                            type: ["object", "null"],
-                            example: {
-                                code: "R1301",
-                                message: "에러 메시지",
-                            },
-                        },
-                    },
+    RecommendationNotFound: {
+      description: "추천 기록이 없습니다.",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: false },
+              data: { type: "object", nullable: true },
+              error: {
+                type: "object",
+                properties: {
+                  errorCode: { type: "string" },
+                  reason: { type: "string" },
+                  data: { type: "object", nullable: true },
                 },
+              },
             },
+          },
         },
+      },
     },
+    NotFoundUserEmailError: {
+      description: "해당 이메일을 찾을 수 없습니다.",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: false },
+              data: { type: "object", nullable: true },
+              error: {
+                type: "object",
+                properties: {
+                  errorCode: { type: "string" },
+                  reason: { type: "string" },
+                  data: { type: "object", nullable: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    NotFoundKeywordError: {
+      description: "검색어를 입력하세요.",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: false },
+              data: { type: "object", nullable: true },
+              error: {
+                type: "object",
+                properties: {
+                  errorCode: { type: "string" },
+                  reason: { type: "string" },
+                  data: { type: "object" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    RecomsSongNotFoundError: {
+      description: "해당 추천곡을 찾을 수 없습니다.",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: false },
+              data: { type: "object", nullable: true },
+              error: {
+                type: "object",
+                properties: {
+                  errorCode: { type: "string" },
+                  reason: { type: "string"},
+                  data: { type: "object", nullable: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    UserMismatchError: {
+      description: "본인이 발신한 추천 곡이 아닙니다. 조회 권한이 없습니다.",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: false },
+              data: { type: "object", nullable: true },
+              error: {
+                type: "object",
+                properties: {
+                  errorCode: { type: "string" },
+                  reason: { type: "string" },
+                  data: { type: "object" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    UnauthorizedError: {
+      description: "Authorization이 제공되지 않았습니다.",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: false },
+              data: { type: "object", nullable: true },
+              error: {
+                type: "object",
+                properties: {
+                  errorCode: { type: "string" },
+                  reason: { type: "string" },
+                  data: { type: "object", nullable: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    TokenError: {
+      description: "토큰을 확인해주세요. (만료된 토큰, 올바르지 않은 토큰, 유효하지 않은 토큰 등)",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", example: false },
+              data: { type: "object", nullable: true },
+              error: {
+                type: "object",
+                properties: {
+                  errorCode: { type: "string" },
+                  reason: { type: "string" },
+                  data: { type: "object", nullable: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 };

--- a/src/configs/auth.config.js
+++ b/src/configs/auth.config.js
@@ -2,7 +2,7 @@ import dotenv from "dotenv";
 import { Strategy as GoogleStrategy } from "passport-google-oauth20";
 import { Strategy as NaverStrategy } from "passport-naver-v2";
 import { Strategy as KakaoStrategy } from "passport-kakao";
-import { NotFoundUserEmailError } from "../errors.js";
+import { NotSupportedSocialLoginError, UnauthorizedError } from "../errors.js";
 import { prisma } from "./db.config.js";
 import { generateToken } from "../utils/token.js";
 import { SocialType, Gender } from "@prisma/client";
@@ -83,11 +83,11 @@ const socialVerify = async (profile, type) => {
             name = account.name;
             email = account.email;
         } else {
-            throw new Error(`${type}은 지원하지 않는 소셜 로그인입니다.`);
+            throw new NotSupportedSocialLoginError("지원하지 않는 소셜 로그인입니다.")
         }
 
         if (!email) {
-            throw new NotFoundUserEmailError("해당 이메일을 찾을 수 없습니다.");
+            throw new UnauthorizedError("소셜 로그인에 실패했습니다. 이메일 정보를 가져올 수 없습니다.")
         }
 
         let user = await prisma.user.findFirst({ where: { email } });
@@ -132,7 +132,6 @@ const socialVerify = async (profile, type) => {
             },
         };
     } catch (err) {
-        console.error("Social verify failed:", err);
-        throw err;
+        next(err);
     }
 };

--- a/src/configs/auth.config.js
+++ b/src/configs/auth.config.js
@@ -2,7 +2,7 @@ import dotenv from "dotenv";
 import { Strategy as GoogleStrategy } from "passport-google-oauth20";
 import { Strategy as NaverStrategy } from "passport-naver-v2";
 import { Strategy as KakaoStrategy } from "passport-kakao";
-import { NotFoundUserEmail } from "../errors.js";
+import { NotFoundUserEmailError } from "../errors.js";
 import { prisma } from "./db.config.js";
 import { generateToken } from "../utils/token.js";
 import { SocialType, Gender } from "@prisma/client";
@@ -87,7 +87,7 @@ const socialVerify = async (profile, type) => {
         }
 
         if (!email) {
-            throw new NotFoundUserEmail("해당 이메일을 찾을 수 없습니다.");
+            throw new NotFoundUserEmailError("해당 이메일을 찾을 수 없습니다.");
         }
 
         let user = await prisma.user.findFirst({ where: { email } });

--- a/src/controllers/recoms.controller.js
+++ b/src/controllers/recoms.controller.js
@@ -1,8 +1,7 @@
 import { StatusCodes } from "http-status-codes";
 import { sentRecomsSong, receivedRecomsSong, searchSong } from "../services/recoms.service.js";
 import { searchSpotifyTracks } from "../services/spotify.service.js";
-import { MissingSearchQueryError } from "../errors.js";
-import { RecommendationNotFoundError } from "../errors.js";
+import { NotFoundKeywordError } from "../errors.js";
 
 
 export const handleAllTracks = async (req, res, next) => {
@@ -33,11 +32,11 @@ export const handleSentRecomsSong = async (req, res, next) => {
     };
 
     #swagger.responses[404] = {
-        $ref: "#/components/responses/Failed"
+        $ref: "#/components/responses/RecomsSongNotFoundError"
     };
 
     #swagger.responses[403] = {
-        $ref: "#/components/responses/Failed"
+        $ref: "#/components/responses/UserMismatchError"
     };
     */
 
@@ -62,11 +61,11 @@ export const handleReceivedRecomsSong = async (req, res, next) => {
     };
 
     #swagger.responses[404] = {
-        $ref: "#/components/responses/Failed"
+        $ref: "#/components/responses/RecomsSongNotFoundError"
     };
 
     #swagger.responses[403] = {
-        $ref: "#/components/responses/Failed"
+        $ref: "#/components/responses/UserMismatchError"
     };
     */
 
@@ -82,98 +81,18 @@ export const searchRecomSong = async (req, res, next) => {
 
   /*
     #swagger.summary = '추천 기록 검색 API'
-    #swagger.security = [{ bearerAuth: [] }]
-    #swagger.parameters['keyword'] = {
-      in: 'query',
-      name: 'keyword',
-      required: true,
-      schema: { type: 'string', example: 'Blueming' },
-      description: '검색어(곡 제목 또는 아티스트명)'
-    }
 
+    #swagger.security = [{
+        bearerAuth: []
+    }]
+    
     #swagger.responses[200] = {
-      description: '검색 성공 응답',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              success: { type: 'boolean', example: true },
-              data: {
-                type: 'object',
-                properties: {
-                  send: {
-                    type: 'array',
-                    description: '내가 발신한 곡 리스트',
-                    items: { $ref: '#/components/schemas/RecomsSongItem' }
-                  },
-                  receive: {
-                    type: 'array',
-                    description: '내가 수신한 곡 리스트',
-                    items: {
-                      allOf: [
-                        { $ref: '#/components/schemas/RecomsSongItem' },
-                        {
-                          type: 'object',
-                          properties: {
-                            senderNickname: { type: 'string', example: 'noshel' }
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              },
-              error: { type: 'object', nullable: true, example: null }
-            }
-          }
-        }
-      }
-    }
-
-    #swagger.responses[400] = {
-      description: '검색어 미입력',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              success: { type: 'boolean', example: false },
-              data: { type: 'string', nullable: true, example: null },
-              error: {
-                type: 'object',
-                properties: {
-                  code: { type: 'string', example: 'RS1300' },
-                  message: { type: 'string', example: '검색어를 입력하세요.' }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+        $ref: "#/components/responses/Success"
+    };
 
     #swagger.responses[404] = {
-      description: '검색 결과 없음',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              success: { type: 'boolean', example: false },
-              data: { type: 'string', nullable: true, example: null },
-              error: {
-                type: 'object',
-                properties: {
-                  code: { type: 'string', example: 'RS1301' },
-                  message: { type: 'string', example: '검색 결과가 없습니다.' }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+        $ref: "#/components/responses/RecomsSongNotFoundError"
+    };
   */  
   try {
     const { keyword } = req.query;
@@ -181,15 +100,15 @@ export const searchRecomSong = async (req, res, next) => {
 
     // 1) 검색어 없으면
     if (!keyword || keyword.trim() === "") {
-      throw new MissingSearchQueryError();
+      throw new NotFoundKeywordError("검색어를 입력하세요.");
     }
 
     const results = await searchSong(userId, keyword);
 
-    // 2) 결과가 없으면
-    if (results.length === 0) {
-      throw new RecommendationNotFoundError();
-    }
+    // // 2) 결과가 없으면
+    // if (results.length === 0) {
+    //   throw new RecommendationNotFoundError("추천 기록이 존재하지 않습니다.");
+    // }
     
     const send = [];
     const receive = [];

--- a/src/controllers/recoms.controller.js
+++ b/src/controllers/recoms.controller.js
@@ -10,6 +10,10 @@ export const handleAllTracks = async (req, res, next) => {
     #swagger.responses[200] = {
       $ref: "#/components/responses/Success"
     };
+
+    #swagger.responses[401] = {
+      $ref: "#/components/responses/TokenError"
+    };
   */
 
     const keyword = req.query.keyword;
@@ -109,6 +113,8 @@ export const searchRecomSong = async (req, res, next) => {
     // if (results.length === 0) {
     //   throw new RecommendationNotFoundError("추천 기록이 존재하지 않습니다.");
     // }
+    
+    // 결과가 없을 때는 백엔드에서 에러 처리 안 하기로 해서 일단 주석처리 해놨습니당 -> statusCode 겹쳐서 하나만 처리
     
     const send = [];
     const receive = [];

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,13 +1,13 @@
-export class NotFoundUserEmailError extends Error {
-    errorCode = "U1301";
-    statusCode = 404;
+export class NotSupportedSocialLoginError extends Error {
+    errorCode = "U1300";
+    statusCode = 401;
 
     constructor(reason, data) {
         super(reason);
         this.reason = reason;
         this.data = data;
     }
-}
+} 
 
 export class NotFoundKeywordError extends Error {
     errorCode = "R1300";
@@ -77,3 +77,5 @@ export class TokenError extends Error {
         this.data = data;
     }
 }
+
+

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,24 +1,4 @@
-export class MissingSearchQueryError extends Error {
-    errorCode = "RS1300";
-
-    constructor(reason = "검색어를 입력하세요.", data = null) {
-        super(reason);
-        this.reason = reason;
-        this.data = data;
-    }
-}
-
-export class RecommendationNotFoundError extends Error {
-    errorCode = "RS1301";
-
-    constructor(reason = "추천 기록이 존재하지 않습니다.", data = null) {
-        super(reason);
-        this.reason = reason;
-        this.data = data;
-    }
-}
-
-export class NotFoundUserEmail extends Error {
+export class NotFoundUserEmailError extends Error {
     errorCode = "U1301";
     statusCode = 404;
 
@@ -29,7 +9,7 @@ export class NotFoundUserEmail extends Error {
     }
 }
 
-export class NotFoundKeyword extends Error {
+export class NotFoundKeywordError extends Error {
     errorCode = "R1300";
     statusCode = 404;
 
@@ -40,8 +20,20 @@ export class NotFoundKeyword extends Error {
     }
 }
 
-export class RecomsSongNotFoundError extends Error {
+export class RecommendationNotFoundError extends Error {
     errorCode = "R1301";
+    statusCode = 404;
+
+    constructor(reason, data = null) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
+
+export class RecomsSongNotFoundError extends Error {
+    errorCode = "R1302";
     statusCode = 404;
 
     constructor(reason, data) {
@@ -52,7 +44,7 @@ export class RecomsSongNotFoundError extends Error {
 }
 
 export class UserMismatchError extends Error {
-    errorCode = "R1302";
+    errorCode = "R1303";
     statusCode = 403;
 
     constructor(reason, data) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import session from "express-session";
 import passport from "passport";
 import { prisma } from "./configs/db.config.js";
 import { googleStrategy, naverStrategy, kakaoStrategy } from "./configs/auth.config.js";
-import { responses } from "./components/components.js";
+import components from "./components/components.js";
 
 dotenv.config();
 
@@ -97,7 +97,7 @@ app.get("/openapi.json", async (req, res, next) => {
         },
         host: "localhost:3000",
         components: {
-            responses,
+            ...components,
             securitySchemes: {
                 bearerAuth: {
                     type: "http",

--- a/src/routes/oauth.router.js
+++ b/src/routes/oauth.router.js
@@ -4,9 +4,33 @@ import passport from "passport";
 
 const router = Router();
 
-router.get("/login/google", passport.authenticate("google"));
+router.get(
+  "/login/google",
+  /*
+    #swagger.summary = "Google 소셜 로그인"
+    #swagger.responses[302] = {
+        $ref: "#/components/responses/SuccessSocialLogin"
+    }
+    
+    #swagger.responses[401] = {
+        $ref: "#/components/responses/NotSupportedSocialLoginError"
+    }
+  */
+  passport.authenticate("google")
+);
+
 router.get(
     "/callback/google",
+    /*
+    #swagger.summary = "Google 소셜 로그인 콜백"
+    #swagger.responses[200] = {
+        $ref: "#/components/responses/Success"
+    }
+    
+    #swagger.responses[401] = {
+        $ref: "#/components/responses/NotSupportedSocialLoginError"
+    }
+  */
     passport.authenticate("google", {
         failureRedirect: "/api/v1/oauth2/login/google",
         failureMessage: true,
@@ -19,9 +43,30 @@ router.get(
         });
     }
 );
-router.get("/login/naver", passport.authenticate("naver"));
+router.get("/login/naver", 
+    /*
+    #swagger.summary = "Naver 소셜 로그인"
+    #swagger.responses[302] = {
+        $ref: "#/components/responses/SuccessSocialLogin"
+    }
+    
+    #swagger.responses[401] = {
+        $ref: "#/components/responses/NotSupportedSocialLoginError"
+    }
+    */
+    passport.authenticate("naver"));
 router.get(
     "/callback/naver",
+    /*
+    #swagger.summary = "Naver 소셜 로그인 콜백"
+    #swagger.responses[200] = {
+        $ref: "#/components/responses/Success"
+    }
+    
+    #swagger.responses[401] = {
+        $ref: "#/components/responses/NotSupportedSocialLoginError"
+    }
+    */
     passport.authenticate("naver", {
         failureRedirect: "/api/v1/oauth2/login/naver",
         failureMessage: true,
@@ -34,9 +79,30 @@ router.get(
         });
     }
 );
-router.get("/login/kakao", passport.authenticate("kakao"));
+router.get("/login/kakao", 
+    /*
+    #swagger.summary = "Kakao 소셜 로그인"
+    #swagger.responses[302] = {
+        $ref: "#/components/responses/SuccessSocialLogin"
+    }
+    
+    #swagger.responses[401] = {
+        $ref: "#/components/responses/NotSupportedSocialLoginError"
+    }
+    */
+    passport.authenticate("kakao"));
 router.get(
     "/callback/kakao",
+    /*
+    #swagger.summary = "Kakao 소셜 로그인 콜백"
+    #swagger.responses[200] = {
+        $ref: "#/components/responses/Success"
+    }
+    
+    #swagger.responses[401] = {
+        $ref: "#/components/responses/NotSupportedSocialLoginError"
+    }
+    */
     passport.authenticate("kakao", {
         failureRedirect: "api/v1/oauth2/login/kakao",
         failureMessage: true,

--- a/src/routes/recoms.router.js
+++ b/src/routes/recoms.router.js
@@ -9,7 +9,7 @@ import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
 
 const router = Router();
 
-router.get("/search-song", handleAllTracks);
+router.get("/recoms/search/song", handleAllTracks);
 router.get("/:recomsId/sent", authenticateAccessToken, handleSentRecomsSong);
 router.get("/:recomsId/received", authenticateAccessToken, handleReceivedRecomsSong);
 router.get("/recoms/search/record", authenticateAccessToken, searchRecomSong);

--- a/src/services/recoms.service.js
+++ b/src/services/recoms.service.js
@@ -1,5 +1,5 @@
 import { sentRecomsResponseDTO, receivedRecomsResponseDTO } from "../dtos/recoms.dto.js";
-import { RecomsSongNotFoundError, UserMismatchError, MissingSearchQueryError } from "../errors.js";
+import { RecomsSongNotFoundError, UserMismatchError, NotFoundKeywordError } from "../errors.js";
 import { getSentRecomsSong, getReceivedRecomsSong, findSongByKeyword } from "../repositories/recoms.repository.js";
 
 export const sentRecomsSong = async (recomsId, userId) => {
@@ -34,8 +34,7 @@ export const receivedRecomsSong = async (recomsId, userId) => {
 
 export const searchSong = async (userId, keyword) => {
     if (!keyword) {
-        throw new MissingSearchQueryError();
+        throw new NotFoundKeywordError("검색어를 입력하세요.");
     }
-
     return await findSongByKeyword(userId, keyword);
 };

--- a/src/services/spotify.service.js
+++ b/src/services/spotify.service.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import qs from 'qs';
 
 import { searchTracksResponseDTO } from '../dtos/recoms.dto.js';
-import { NotFoundKeyword } from '../errors.js';
+import { NotFoundKeywordError } from '../errors.js';
 
 export async function getSpotifyToken() {
   const clientId = process.env.SPOTIFY_CLIENT_ID;
@@ -44,8 +44,6 @@ export async function searchSpotifyTracks(keyword, cursor) {
       limit: 20
     },
   });
-
-  console.log(res.data.tracks.items);
 
     const result = res.data.tracks.items.map((track) =>
         searchTracksResponseDTO({

--- a/src/services/spotify.service.js
+++ b/src/services/spotify.service.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import qs from 'qs';
 
 import { searchTracksResponseDTO } from '../dtos/recoms.dto.js';
-import { NotFoundKeywordError } from '../errors.js';
+import { TokenError } from '../errors.js';
 
 export async function getSpotifyToken() {
   const clientId = process.env.SPOTIFY_CLIENT_ID;
@@ -32,6 +32,9 @@ export async function getSpotifyToken() {
 export async function searchSpotifyTracks(keyword, cursor) {
 
   const token = await getSpotifyToken();
+  if(!token){
+    TokenError("유효하지 않은 스포티파이 토큰입니다.");
+  }
 
   const res = await axios.get('https://api.spotify.com/v1/search', {
     headers: {


### PR DESCRIPTION
## 이슈번호 26#<!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
전체 공통 응답 형식을 components.js에 맞춰 변경했습니다.

---


### 🔍 참고 사항  
현재 구현된 모든 API 응답 형식을 components.js에서 불러오는 것으로 통일했습니다.
꼭 ! components/components.js 파일과 erros.js 파일을 확인하셔서 같은 에러가 있는지 확인 후
errors.js 에서 불러올 때는 ```new [Error명] ("에러 메세지")``` 로,
스웨거 형식을 불러올 때는 ```#swagger.responses[HTTPS 상태코드] = { $ref: "#/components/responses/[Error명]" } ``` 형식으로 사용해주세요 !
단, 한 API 에서 상태 코드가 중복되면 안되니, 유의해서 사용해주세요

ex) 로그인할 때 상태코드가 401인 에러 UnauthorizedError와 TokenError를 분리하여 사용할 수 없습니다.

---


### 🖼️ 스크린샷  

---

### 🔗 관련 이슈  

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
