### PR TITLE
[FEAT] 곡 추천하기 API 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "aws-sdk": "^2.1692.0",
                 "axios": "^1.10.0",
                 "cors": "^2.8.5",
+                "date-fns": "^4.1.0",
                 "dotenv": "^17.2.0",
                 "express": "^5.0.0",
                 "express-session": "^1.18.1",
@@ -525,6 +526,16 @@
             },
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "aws-sdk": "^2.1692.0",
         "axios": "^1.10.0",
         "cors": "^2.8.5",
+        "date-fns": "^4.1.0",
         "dotenv": "^17.2.0",
         "express": "^5.0.0",
         "express-session": "^1.18.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,16 +8,16 @@ datasource db {
 }
 
 model UserLikedArtist {
-  id              String       @id @unique @default(uuid())
-  createdAt       DateTime     @default(now()) @map("created_at")
-  updatedAt       DateTime     @updatedAt @map("updated_at")
-  artistId        String       @map("artist_id")
-  userId          String       @map("user_id")
-  artistName      String       @map("artist_name")
-  imgUrl          String       @map("img_url")
-  inactiveAt      DateTime?    @map("inactive_at")
-  inactiveStatus  Boolean      @default(false) @map("inactive_status")
-  user            User     @relation(fields: [userId], references: [id])
+  id             String    @id @unique @default(uuid())
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
+  artistId       String    @map("artist_id")
+  userId         String    @map("user_id")
+  artistName     String    @map("artist_name")
+  imgUrl         String    @map("img_url")
+  inactiveAt     DateTime? @map("inactive_at")
+  inactiveStatus Boolean   @default(false) @map("inactive_status")
+  user           User      @relation(fields: [userId], references: [id])
 }
 
 model Inquiry {
@@ -33,6 +33,7 @@ model RecomsSong {
   title           String           @db.VarChar(100)
   artistName      String           @map("artist_name")
   imgUrl          String?          @map("img_url")
+  preview_url     String?
   userRecomsSongs UserRecomsSong[]
 }
 
@@ -56,25 +57,25 @@ model RecomsReply {
   content          String
   createdAt        DateTime       @default(now()) @map("created_at")
   updatedAt        DateTime       @updatedAt @map("updated_at")
-  userRecomsSongId String         @map("user_recoms_song_id")
+  userRecomsSongId String         @unique @map("user_recoms_song_id")
   responderId      String         @map("responder_id")
   responder        User           @relation(fields: [responderId], references: [id])
   userRecomsSong   UserRecomsSong @relation(fields: [userRecomsSongId], references: [id])
 }
 
 model UserRecomsSong {
-  id           String        @id @unique @default(uuid())
-  senderId     String        @map("sender_id")
-  recomsSongId String        @map("recoms_song_id")
-  receiverId   String        @map("receiver_id")
-  createdAt    DateTime      @default(now()) @map("created_at")
-  isAnoymous   Boolean       @default(false) @map("is_anoymous")
-  isLiked      Boolean       @default(false) @map("is_liked")
+  id           String       @id @unique @default(uuid())
+  senderId     String       @map("sender_id")
+  recomsSongId String       @map("recoms_song_id")
+  receiverId   String?      @map("receiver_id")
+  createdAt    DateTime     @default(now()) @map("created_at")
+  isAnoymous   Boolean      @default(false) @map("is_anoymous")
+  isLiked      Boolean?     @default(false) @map("is_liked")
   comment      String
-  replies      RecomsReply[]
-  receiver     User          @relation("UserReceivedRecom", fields: [receiverId], references: [id])
-  recomsSong   RecomsSong    @relation(fields: [recomsSongId], references: [id])
-  sender       User          @relation("UserSentRecom", fields: [senderId], references: [id])
+  replies      RecomsReply?
+  receiver     User?        @relation("UserReceivedRecom", fields: [receiverId], references: [id])
+  recomsSong   RecomsSong   @relation(fields: [recomsSongId], references: [id])
+  sender       User         @relation("UserSentRecom", fields: [senderId], references: [id])
 }
 
 model User {
@@ -97,11 +98,11 @@ model User {
   fcmTokens       FcmToken[]
   receivedNotices Notification[]    @relation("NotificationReceiver")
   sentNotices     Notification[]    @relation("NotificationSender")
+  notifications   NotificationType?
   recomsReplies   RecomsReply[]
   likedArtist     UserLikedArtist[]
   receivedRecoms  UserRecomsSong[]  @relation("UserReceivedRecom")
   sentRecoms      UserRecomsSong[]  @relation("UserSentRecom")
-  notifications   NotificationType?
 }
 
 model FcmToken {
@@ -115,21 +116,21 @@ model FcmToken {
 model Session {
   id        String   @id @default(uuid())
   sid       String   @unique
-  data      String   @db.VarChar(512)
+  data      String
   expiresAt DateTime @map("expires_at")
 
   @@map("session")
 }
 
 model NotificationType {
-  id              String     @id @unique @default(uuid())
-  userId          String     @map("user_id") @unique
-  recomsReceived  Boolean    @map("recoms_received") @default(true)
-  recomsSent      Boolean    @map("recoms_sent") @default(true)
-  commentArrived  Boolean    @map("comment_arrived") @default(true)
-  notRecoms       Boolean    @map("not_recoms") @default(true)
-  announcement    Boolean    @default(true)
-  user            User       @relation(fields: [userId], references: [id])
+  id             String  @id @unique @default(uuid())
+  userId         String  @unique @map("user_id")
+  recomsReceived Boolean @default(true) @map("recoms_received")
+  recomsSent     Boolean @default(true) @map("recoms_sent")
+  commentArrived Boolean @default(true) @map("comment_arrived")
+  notRecoms      Boolean @default(true) @map("not_recoms")
+  announcement   Boolean @default(true)
+  user           User    @relation(fields: [userId], references: [id])
 }
 
 enum Gender {

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -213,6 +213,94 @@ export default {
                 }
             }
         }
-    }
+    },
+    NoUserError: {
+        description: "사용자를 찾을 수 없습니다. 로그인 후 이용부탁드립니다.",
+        content: {
+            "application/json": {
+                schema:{
+                    type: "object",
+                    properties: {
+                        success: { type: "boolean", example: false },
+                        data: {type: "object", nullable: true},
+                        error: {
+                            type: "object",
+                            properties: {
+                                errorCode: { type: "string" },
+                                reason: { type: "string" },
+                                data: { type: "object", nullable: true },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    DuplicateRecoms: {
+        description: "오늘은 이미 노래를 추천하셨습니다.",
+        content: {
+            "application/json": {
+                schema:{
+                    type: "object",
+                    properties: {
+                        success: { type: "boolean", example: false },
+                        data: {type: "object", nullable: true},
+                        error: {
+                            type: "object",
+                            properties: {
+                                errorCode: { type: "string" },
+                                reason: { type: "string" },
+                                data: { type: "object", nullable: true },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    NotFoundSongError: {
+        description: "트랙 ID가 존재하지 않습니다.",
+        content: {
+            "application/json": {
+                schema:{
+                    type: "object",
+                    properties: {
+                        success: { type: "boolean", example: false },
+                        data: {type: "object", nullable: true},
+                        error: {
+                            type: "object",
+                            properties: {
+                                errorCode: { type: "string" },
+                                reason: { type: "string" },
+                                data: { type: "object", nullable: true },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    RecomsSongNotFoundError: {
+        description: "트랙 ID가 존재하지 않습니다.",
+        content: {
+            "application/json": {
+                schema:{
+                    type: "object",
+                    properties: {
+                        success: { type: "boolean", example: false },
+                        data: {type: "object", nullable: true},
+                        error: {
+                            type: "object",
+                            properties: {
+                                errorCode: { type: "string" },
+                                reason: { type: "string" },
+                                data: { type: "object", nullable: true },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
   },
-};
+}

--- a/src/controllers/recoms.controller.js
+++ b/src/controllers/recoms.controller.js
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { sentRecomsSong, receivedRecomsSong, searchSong } from "../services/recoms.service.js";
+import { sentRecomsSong, receivedRecomsSong, searchSong, addRecoms } from "../services/recoms.service.js";
 import { searchSpotifyTracks } from "../services/spotify.service.js";
 import { NotFoundKeywordError } from "../errors.js";
 
@@ -15,12 +15,15 @@ export const handleAllTracks = async (req, res, next) => {
       $ref: "#/components/responses/TokenError"
     };
   */
+  try{
+        const keyword = req.query.keyword;
+        const cursor = typeof req.query.cursor === "string" ? parseInt(req.query.cursor) : 0;
 
-    const keyword = req.query.keyword;
-    const cursor = typeof req.query.cursor === "string" ? parseInt(req.query.cursor) : 0;
-
-    const tracks = await searchSpotifyTracks(keyword, cursor);
-    res.status(StatusCodes.OK).success(tracks);
+        const tracks = await searchSpotifyTracks(keyword, cursor);
+        res.status(StatusCodes.OK).success(tracks);
+  }catch(err){
+    next(err);
+  }
 };
 
 export const handleSentRecomsSong = async (req, res, next) => {
@@ -144,3 +147,26 @@ export const searchRecomSong = async (req, res, next) => {
         next(err);
     }
 };
+
+export const handleAddRecoms = async (req, res, next) => {
+    /*
+    #swagger.summary = '노래 추천하기 API'
+
+    #swagger.security = [{
+        bearerAuth: []
+    }]
+
+    #swagger.responses[200] = {
+        $ref: "#/components/responses/Success"
+    };
+    */
+
+    try {
+        const userId = req.user.id;
+        const recomsSongId = await addRecoms(req.body, userId);
+        console.log(req.body);
+        res.status(StatusCodes.OK).success(recomsSongId);
+    } catch (err) {
+        next(err);
+    }
+}

--- a/src/controllers/recoms.controller.js
+++ b/src/controllers/recoms.controller.js
@@ -159,6 +159,22 @@ export const handleAddRecoms = async (req, res, next) => {
     #swagger.responses[200] = {
         $ref: "#/components/responses/Success"
     };
+
+    #swagger.responses[400] = {
+        $ref: "#/components/responses/NotFoundSongError"
+    };
+
+    #swagger.responses[401] = {
+        $ref: "#/components/responses/NoUserError"
+    };
+
+    #swagger.responses[409] = {
+        $ref: "#/components/responses/DuplicateRecoms"
+    };
+
+    #swagger.responses[409] = {
+        $ref: "#/components/responses/RecomsSongNotFoundError"
+    };
     */
 
     try {

--- a/src/dtos/recoms.dto.js
+++ b/src/dtos/recoms.dto.js
@@ -45,3 +45,29 @@ export const receivedRecomsResponseDTO = (recomsData) => {
         replyId: recomsData.replies[0] ? recomsData.replies[0].id : null,
     };
 };
+
+export const getSongInfoResponseDTO = (songData) => {
+    //console.log(songData);
+    const artists =songData.artists.map(artist => artist.name).join(", ");
+        
+    return {
+        id: songData.id,
+        title: songData.name,
+        artistName: artists,
+        imgUrl : songData.album.images?.[0]?.url || null,
+        previewUrl: songData.preview_url || null
+    }
+}
+
+export const userRecomsSongResponseDTO = (userRecomsSongData) => {
+    return {
+        id: userRecomsSongData.id,
+        recomsSong: {
+            id: userRecomsSongData.recomsSongId,
+        },
+        sender: {
+            id: userRecomsSongData.senderId
+        },
+        comment: userRecomsSongData.comment
+    }
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,3 +1,4 @@
+// 도메인 : User
 export class NotSupportedSocialLoginError extends Error {
     errorCode = "U1300";
     statusCode = 401;
@@ -7,7 +8,30 @@ export class NotSupportedSocialLoginError extends Error {
         this.reason = reason;
         this.data = data;
     }
-} 
+}
+
+export class NoUserError extends Error {
+    errorCode = "U1301";
+    statusCode = 404;
+
+    constructor(reason,data){
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
+// 도메인 : Recoms
+export class DuplicateRecoms extends Error {
+    errorCode = "R1200";
+    statusCode = 409;
+
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
 
 export class NotFoundKeywordError extends Error {
     errorCode = "R1300";
@@ -54,6 +78,8 @@ export class UserMismatchError extends Error {
     }
 }
 
+
+// 도메인 : Token
 // 인증 정보가 제공되어 있지 않은 경우
 export class UnauthorizedError extends Error {
     errorCode = "T1200";
@@ -79,3 +105,14 @@ export class TokenError extends Error {
 }
 
 
+// 도메인 : Spotify
+export class NotFoundSongError extends Error {
+    errorCode = "S1300";
+    statusCode = 400;
+
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -12,7 +12,7 @@ export class NotSupportedSocialLoginError extends Error {
 
 export class NoUserError extends Error {
     errorCode = "U1301";
-    statusCode = 404;
+    statusCode = 401;
 
     constructor(reason,data){
         super(reason);

--- a/src/middlewares/authenticate.jwt.js
+++ b/src/middlewares/authenticate.jwt.js
@@ -8,9 +8,9 @@ dotenv.config();
 const { JWT_SECRET } = process.env;
 
 /**
- * Bearer 토큰을 추출하고 검증하는 미들웨어
- * 로그인한 사용자만 접근 가능한 API에 사용
- */
+ 
+Bearer 토큰을 추출하고 검증하는 미들웨어
+로그인한 사용자만 접근 가능한 API에 사용*/
 export const authenticateAccessToken = (req, res, next) => {
     const authHeader = req.headers.authorization;
 
@@ -48,11 +48,11 @@ export const authenticateAccessToken = (req, res, next) => {
             console.log("JWT 토큰 검증 성공", {
                 action: "token:authenticate",
                 actionType: "success",
-                userId: user.userId,
+                userId: user.id,
             });
 
             req.user = {
-                userId: user.userId,
+                id: user.id,
             }; // 검증된 사용자 정보를 요청 객체에 추가
             next();
         });
@@ -60,11 +60,10 @@ export const authenticateAccessToken = (req, res, next) => {
         next(new UnauthorizedError("Authorization이 제공되지 않았습니다."));
     }
 };
-
 /**
- * 로그인된 경우에만 사용자 권한을 검증하는 미들웨어
- * 로그인한 사용자는 유저 정보를, 비로그인은 null 처리하는 API에 사용
- */
+ 
+로그인된 경우에만 사용자 권한을 검증하는 미들웨어
+로그인한 사용자는 유저 정보를, 비로그인은 null 처리하는 API에 사용*/
 export const autheticateAccessTokenIfExists = (req, res, next) => {
     const authHeader = req.headers.authorization;
 
@@ -94,7 +93,7 @@ export const autheticateAccessTokenIfExists = (req, res, next) => {
                 // }
 
                 req.user = {
-                    userId: null,
+                    id: null,
                 };
                 return next();
             }
@@ -102,11 +101,11 @@ export const autheticateAccessTokenIfExists = (req, res, next) => {
             console.log("JWT 토큰 검증 성공", {
                 action: "token:authenticate",
                 actionType: "success",
-                userId: user.userId,
+                userId: user.id,
             });
 
             req.user = {
-                userId: user.userId,
+                id: user.id,
             }; // 검증된 사용자 정보를 요청 객체에 추가
 
             // 확인용
@@ -116,7 +115,7 @@ export const autheticateAccessTokenIfExists = (req, res, next) => {
         });
     } else {
         req.user = {
-            userId: null,
+            id: null,
         };
 
         // 확인용

--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -1,4 +1,5 @@
 import { prisma } from "../configs/db.config.js";
+import { startOfDay, endOfDay } from 'date-fns';
 
 // 발신한 추천 곡 반환
 export const getSentRecomsSong = async (recomsId) => {
@@ -84,3 +85,53 @@ export const findSongByKeyword = async (userId, keyword) => {
         },
     });
 };
+
+export const getSenderToday = async (userId) => {
+    return await prisma.userRecomsSong.findFirst({
+        where: {
+            senderId: userId,
+            createdAt: {
+                // 오늘과 생성 날짜가 같은지 (하루에 2번 추천하는지 확인 용도)
+                gte: startOfDay(new Date()),
+                lt: endOfDay(new Date()),
+            },
+        }
+    })
+}
+ 
+export const getRecomsSong = async (recomsSongId) => {
+    return await prisma.recomsSong.findUnique({
+        where: {
+            id: recomsSongId
+        }
+    })
+}
+
+export const createRecomsSong = async (recomsSong) => {
+    const created = await prisma.recomsSong.create({
+      data: {
+        id: recomsSong.id,
+        title: recomsSong.title,
+        artistName: recomsSong.artistName,
+        imgUrl: recomsSong.imgUrl,
+        previewUrl: recomsSong.preview_url
+      }
+    });
+    return created;
+}
+
+export const createUserRecomsSong = async (data, userId, recomsSong) => {
+    const created = await prisma.userRecomsSong.create({
+        data: {
+            sender: {
+                connect: { id : userId}
+            },
+            recomsSong: {
+                connect: { id : recomsSong.id }
+            },
+            isAnoymous: data.isAnoymous,
+            comment: data.comment
+        }
+    });
+    return created;
+}

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -1,0 +1,8 @@
+import { prisma } from "../configs/db.config.js";
+
+export const getUser = async (userId) => {
+    const userData = await prisma.user.findUnique({
+        where: {id: userId}
+    })
+    return userData;
+}

--- a/src/routes/recoms.router.js
+++ b/src/routes/recoms.router.js
@@ -4,14 +4,16 @@ import {
     handleSentRecomsSong,
     handleReceivedRecomsSong,
     searchRecomSong,
+    handleAddRecoms
 } from "../controllers/recoms.controller.js";
 import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
 
 const router = Router();
 
-router.get("/recoms/search/song", handleAllTracks);
+router.get("/search/song", handleAllTracks);
 router.get("/:recomsId/sent", authenticateAccessToken, handleSentRecomsSong);
 router.get("/:recomsId/received", authenticateAccessToken, handleReceivedRecomsSong);
-router.get("/recoms/search/record", authenticateAccessToken, searchRecomSong);
+router.get("/search/record", authenticateAccessToken, searchRecomSong);
+router.post("/",authenticateAccessToken, handleAddRecoms);
 
 export default router;

--- a/src/services/recoms.service.js
+++ b/src/services/recoms.service.js
@@ -1,6 +1,8 @@
-import { sentRecomsResponseDTO, receivedRecomsResponseDTO } from "../dtos/recoms.dto.js";
-import { RecomsSongNotFoundError, UserMismatchError, NotFoundKeywordError } from "../errors.js";
-import { getSentRecomsSong, getReceivedRecomsSong, findSongByKeyword } from "../repositories/recoms.repository.js";
+import { sentRecomsResponseDTO, receivedRecomsResponseDTO, userRecomsSongResponseDTO } from "../dtos/recoms.dto.js";
+import { RecomsSongNotFoundError, UserMismatchError, NotFoundKeywordError, NoUserError, DuplicateRecoms, NotFoundSongError } from "../errors.js";
+import { getSentRecomsSong, getReceivedRecomsSong, findSongByKeyword, getSenderToday, getRecomsSong, createRecomsSong, createUserRecomsSong } from "../repositories/recoms.repository.js";
+import { getUser } from "../repositories/users.repository.js";
+import { getSongInfo } from "./spotify.service.js";
 
 export const sentRecomsSong = async (recomsId, userId) => {
     const recomsData = await getSentRecomsSong(recomsId);
@@ -38,3 +40,36 @@ export const searchSong = async (userId, keyword) => {
     }
     return await findSongByKeyword(userId, keyword);
 };
+
+export const addRecoms = async(data, userId) => {
+    // 로그인한 사용자인지 확인 
+    const recomsUser = await getUser(userId);
+    if(!recomsUser){
+        throw new NoUserError("사용자를 찾을 수 없습니다. 로그인 후 이용부탁드립니다.");
+    }
+
+    // 오늘 추천한 적 있는지 확인
+    const existUser = await getSenderToday(userId);
+    if(existUser){
+        throw new DuplicateRecoms("오늘은 이미 노래를 추천하셨습니다.");
+    }
+
+    // recomsSong 테이블에 데이터 생성
+    let recomsSong = await getRecomsSong(data.id);
+    if(!recomsSong){
+        const songData = await getSongInfo(data.id);
+        console.log(songData);
+        if(!songData){
+            throw new NotFoundSongError("트랙 ID가 존재하지 않습니다.");
+        }
+        recomsSong = await createRecomsSong(songData);
+    }
+
+    //UserRecomsSong 테이블에 데이터 생성
+    if(!recomsSong){
+        throw new RecomsSongNotFoundError("recomsSong 테이블에 데이터가 생성되지 않았습니다.");
+    }
+
+    const newUserSongData = await createUserRecomsSong(data,userId,recomsSong);
+    return userRecomsSongResponseDTO(newUserSongData);
+}

--- a/src/services/spotify.service.js
+++ b/src/services/spotify.service.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import qs from 'qs';
 
-import { searchTracksResponseDTO } from '../dtos/recoms.dto.js';
-import { TokenError } from '../errors.js';
+import { searchTracksResponseDTO, getSongInfoResponseDTO } from '../dtos/recoms.dto.js';
+import { NotFoundSongError, TokenError, NotFoundKeywordError } from '../errors.js';
 
 export async function getSpotifyToken() {
   const clientId = process.env.SPOTIFY_CLIENT_ID;
@@ -23,39 +23,74 @@ export async function getSpotifyToken() {
 
     return response.data.access_token;
   } catch (error) {
-    console.error('Error fetching Spotify token:', error.response?.data || error.message);
-    throw new Error('Spotify token fetch failed');
+    console.error("Spotify 토큰 발급 실패:", err.response?.data || err.message);
+    throw new Error("Spotify 토큰 발급 중 알 수 없는 오류가 발생했습니다.");
   }
 }
 
-// 추천할 노래 검색 (추천 수신할 때)
-export async function searchSpotifyTracks(keyword, cursor) {
-
+export async function searchSpotifyTracks(keyword, cursor = 0) {
   const token = await getSpotifyToken();
-  if(!token){
-    TokenError("유효하지 않은 스포티파이 토큰입니다.");
+  if (!token) {
+    throw new TokenError("유효하지 않은 스포티파이 토큰입니다.");
   }
 
-  const res = await axios.get('https://api.spotify.com/v1/search', {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    params: {
-      q: keyword,
-      type: 'track',
-      offset: cursor,
-      limit: 20
-    },
-  });
+  try {
+    const res = await axios.get('https://api.spotify.com/v1/search', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params: {
+        q: keyword,
+        type: 'track',
+        offset: cursor,
+        limit: 20,
+      },
+    });
 
     const result = res.data.tracks.items.map((track) =>
-        searchTracksResponseDTO({
-            id: track.id,
-            artist: track.artists.map(a => a.name).join(', '),
-            album: track.album.name,
-            albumImg: track.album.images?.[0]?.url || null
-        })
+      searchTracksResponseDTO({
+        id: track.id,
+        artist: track.artists.map((a) => a.name).join(', '),
+        album: track.album.name,
+        albumImg: track.album.images?.[0]?.url || null,
+      })
     );
 
-  return result;
+    return result;
+  } catch (err) {
+    console.error("Spotify 트랙 검색 실패:", err.response?.data || err.message);
+
+    if (err.response && err.response.status === 400) {
+      throw new NotFoundKeywordError("검색어가 없거나 잘못된 요청입니다.");
+    }
+
+    throw new Error("Spotify 트랙 검색 중 알 수 없는 오류가 발생했습니다.");
+  }
+}
+
+export async function getSongInfo(songId) {
+  const token = await getSpotifyToken();
+  if (!token) {
+    throw new TokenError("유효하지 않은 스포티파이 토큰입니다.");
+  }
+
+  try {
+    const res = await axios.get(`https://api.spotify.com/v1/tracks/${songId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const result = getSongInfoResponseDTO(res.data);
+    return result;
+
+  } catch (err) {
+    console.error("Spotify API 요청 실패:", err.response?.data || err.message);
+
+    if (err.response && err.response.status === 400) {
+      throw new NotFoundSongError("트랙 ID가 잘못되었거나 존재하지 않습니다.");
+    }
+
+    throw new Error("Spotify 요청 중 알 수 없는 오류가 발생했습니다.");
+  }
 }


### PR DESCRIPTION
## 이슈번호 #29<!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
- 곡 추천하기 API 구현 완료

---


### 🔍 참고 사항  
- preview_url 변경 안돼서 일단 preview_url로 진행했습니다.
  - 추후 RecomsSong 테이블의 preview_url -> previewUrl로 변경 필요
-  아티스트가 여러명일 때, 하나의 String으로 반환하도록 구현했습니다.
  ex) [도겸, 에스쿱스, 호시] 일 때, ```도겸, 에스쿱스, 호시``` 로 출력
- 프론트에서 필요한 데이터에 맞춰 추후 수정 예정

일단 제 머리에서 나온 로직으로 구현했는데, 추가하거나 수정할 부분 있으면 말해주세요!
1. userRecomsSong 의 createdAt 이랑 현재 시간을 비교하여 sender이 일치하고, 날짜가 오늘인 데이터 존재하면, 이미 추천했다고 간주
2.  추천하고자 하는 곡의 id가 recomsSong 테이블에 존재하면, 누군가 이전에 추천한 적 있는 노래로 간주 
  -> recomsSong 에는 데이터를 삽입하지 않고 userRecomsSong에만 데이터 삽입
3. recomsSong에도 존재하지 않고, userRecomsSong에도 존재하지 않으면, 처음 추천된 노래
  -> recomsSong 과 userRecomsSong 테이블에 모두 삽입
 
---


### 🖼️ 스크린샷 
- 1번 경우
   <img width="872" height="560" alt="image" src="https://github.com/user-attachments/assets/f0cb7f39-973e-45c7-a4df-5f40a158a7de" />

- 2번 & 3번 경우
  <img width="847" height="679" alt="image" src="https://github.com/user-attachments/assets/1b45197f-8c5f-48ff-99d7-57c3735b710e" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
