### PR TITLE
[FIX] 추천할 노래 검색할 때 노래 제목도 같이 반환하도록 수정

### DIFF
--- a/src/services/spotify.service.js
+++ b/src/services/spotify.service.js
@@ -47,14 +47,19 @@ export async function searchSpotifyTracks(keyword, cursor = 0) {
       },
     });
 
+    // console.log(res.data.tracks);
+
     const result = res.data.tracks.items.map((track) =>
       searchTracksResponseDTO({
         id: track.id,
+        title: track.name,
         artist: track.artists.map((a) => a.name).join(', '),
         album: track.album.name,
         albumImg: track.album.images?.[0]?.url || null,
       })
     );
+
+    console.log(result);
 
     return result;
   } catch (err) {


### PR DESCRIPTION
### 📌 작업한 내용  
- 추천할 노래를 검색할 때 노래 제목이 프론트 입장에서 필요할 것 같아 노래 제목을 DTO에 추가해줬습니다.

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 
<img width="855" height="507" alt="image" src="https://github.com/user-attachments/assets/b37d9615-79a4-4548-9e83-648a3c8eac35" />


---