### PR TITLE
[FEAT] 회원정보 수정 API 구현

### DIFF
--- a/src/components/components.js
+++ b/src/components/components.js
@@ -344,5 +344,27 @@ export default {
                 }
             }
         },
+        NoModifyDataError: {
+            description: "수정할 데이터가 없습니다.",
+            content: {
+                "application/json": {
+                    schema:{
+                        type: "object",
+                        properties: {
+                            success: { type: "boolean", example: false },
+                            data: {type: "object", nullable: true},
+                            error: {
+                                type: "object",
+                                properties: {
+                                    errorCode: { type: "string" },
+                                    reason: { type: "string" },
+                                    data: { type: "object", nullable: true },
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     },
 }

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -1,7 +1,9 @@
 import { StatusCodes } from "http-status-codes";
 import {
     checkOwnId,
+    modifyUserInfo,
 } from "../services/users.service.js"
+import { userInfoRequestDTO } from "../dtos/users.dto.js";
 
 export const handleCheckOwnId = async (req, res, next) => {
     /*
@@ -27,5 +29,50 @@ export const handleCheckOwnId = async (req, res, next) => {
     }catch(err){
         next(err);
     }
+}
 
+export const handleModifyUserInfo = async (req, res, next) => {
+    /*
+    #swagger.summary = '회원 정보 수정 API';
+
+    #swagger.security = [{
+        bearerAuth: []
+    }]
+
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              nickname: { type: "string" },
+              ownId: { type: "string" },
+              gender: { type: "string" },
+              birth: { type: "string", format: "date" },
+              recomsTime: { type: "string" },
+              bio: { type: "string" },
+            },
+          }
+        }
+      }
+    };
+    #swagger.responses[200] = {
+      $ref: "#/components/responses/Success"
+    };
+    #swagger.responses[400] = {
+      $ref: "#/components/responses/NoModifyDataError"
+    };
+    #swagger.responses[401] = {
+      $ref: "#/components/responses/TokenError"
+    };
+          
+  */
+  
+  const userId = req.user.id;
+  console.log(req.body)
+  const user = await modifyUserInfo(userId, userInfoRequestDTO({
+    ...req.body,
+  }));
+  res.status(StatusCodes.OK).success(user);
 }

--- a/src/dtos/recoms.dto.js
+++ b/src/dtos/recoms.dto.js
@@ -55,7 +55,7 @@ export const getSongInfoResponseDTO = (songData) => {
         title: songData.name,
         artistName: artists,
         imgUrl: songData.album.images?.[0]?.url || null,
-        previewUrl: songData.preview_url || null,
+        previewUrl: songData.previewUrl || null,
     };
 };
 

--- a/src/dtos/users.dto.js
+++ b/src/dtos/users.dto.js
@@ -1,0 +1,12 @@
+export const userInfoRequestDTO = (body) => {
+    const birth = new Date(body.birth);
+  
+    return {
+      nickname: body.name,
+      ownId: body.ownId,
+      gender: body.gender,
+      birth: birth,
+      bio: body.bio,
+      recomsTime: body.recomsTime,
+    };
+  };

--- a/src/errors.js
+++ b/src/errors.js
@@ -123,3 +123,14 @@ export class RequestBodyError extends Error {
         this.data = data;
     }
 }
+
+export class NoModifyDataError extends Error {
+    errorCode = "1300";
+    statusCode = 400;
+
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}

--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -114,7 +114,7 @@ export const createRecomsSong = async (recomsSong) => {
             title: recomsSong.title,
             artistName: recomsSong.artistName,
             imgUrl: recomsSong.imgUrl,
-            previewUrl: recomsSong.preview_url,
+            previewUrl: recomsSong.previewUrl,
         },
     });
     return created;

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -13,3 +13,12 @@ export const getUserByOwnId = async (checkingOwnId) => {
     })
     return userData;
 }
+
+export const modifyUser = async (userId, data) => {
+  const updatedUser = await prisma.user.update({
+    where: { id: userId },
+    data: data,
+  });
+
+  return updatedUser;
+}

--- a/src/routes/users.router.js
+++ b/src/routes/users.router.js
@@ -1,10 +1,11 @@
 import { Router } from "express";
-import { handleCheckOwnId } from "../controllers/users.controller.js";
+import { handleCheckOwnId, handleModifyUserInfo } from "../controllers/users.controller.js";
 import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
 
 const router = Router();
 
 router.get("/check-ownId", authenticateAccessToken, handleCheckOwnId);
+router.patch("/me/profiles", authenticateAccessToken, handleModifyUserInfo);
 
 export default router;
 

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -1,5 +1,8 @@
+import { NoModifyDataError, NoUserError } from "../errors.js";
 import {
-    getUserByOwnId
+    getUserById,
+    getUserByOwnId,
+    modifyUser
 } from "../repositories/users.repository.js";
 
 export const checkOwnId = async (userOwnId) => {
@@ -10,4 +13,42 @@ export const checkOwnId = async (userOwnId) => {
     }
     console.log("아이디 중복 아님 / 사용 가능");
     return true;
+}
+
+export const modifyUserInfo = async (userId, data) => {
+     const allowedFields = ["nickname","ownId","gender","birth","recomsTime","bio"];
+
+  const user = await getUserById(userId);
+  if (!user) {
+    throw new NoUserError("존재하지 않는 사용자 ID입니다.");
+  }
+
+  const updates = {};
+
+  for (const field of allowedFields) {
+    const value = data[field];
+    if (value !== undefined && value !== "") {
+      updates[field] = value;
+    }
+  }
+
+  // 날짜 형식 변환
+  if (updates.birth) {
+    const parsedDate = new Date(updates.birth);
+    if (!isNaN(parsedDate.getTime())) {
+      updates.birth = parsedDate;
+    } else {
+      delete updates.birth;
+    }
+  }
+  console.log("updates:", updates);
+
+  const isModified = allowedFields.some(field => data[field] != undefined);
+  if (!isModified) {
+    throw new NoModifyDataError("수정할 데이터가 없습니다.");
+  }
+
+  const updatedUser = await modifyUser(user.id, updates);
+
+  return { userId: updatedUser.id };
 }


### PR DESCRIPTION
## 이슈번호 #42<!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
이 PR에서 변경된 내용을 간략히 작성해주세요.
- 회원정보 수정 및  추가할 수 있는 기능 구현
---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.
- 수정하고 싶은 데이터 (0개 ~ 전체) 원하는 만큼 request body에 넣어주면 넣어준 데이터들만 전체 수정하도록 함
- 프론트에서 굳이 바꾼 데이터를 받을 필요가 없다고 판단하여 userId만 반환하나, 추후 프론트와 논의하여 원하는 방향으로 변경 예정
---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 
- 수정할 데이터가 1개일 경우
  <img width="847" height="520" alt="image" src="https://github.com/user-attachments/assets/647d7f45-66a4-4d46-867f-6031c6d89bcb" />

- 수정할 데이터가 2개 이상일 경우
<img width="872" height="555" alt="image" src="https://github.com/user-attachments/assets/e96814c5-2f0c-41c4-bad4-3c4e8ca1f460" />

결과 확인
<img width="1724" height="359" alt="image" src="https://github.com/user-attachments/assets/7c8b1a83-6eec-4367-b0e1-c4fbb716689b" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인
