### PR TITLE
[FEAT] : 추천 기록 리스트 조회 API Swagger 작성

### DIFF
--- a/src/controllers/recoms.controller.js
+++ b/src/controllers/recoms.controller.js
@@ -400,6 +400,26 @@ export const handleSendReplies = async (req, res, next) => {
 };
 
 export const handleListRecomSong = async (req, res, next) => {
+    /*
+        #swagger.summary = '추천 기록 리스트 조회 API'
+
+        #swagger.security = [{
+            bearerAuth: []
+        }]
+
+        #swagger.responses[200] = {
+            $ref: "#/components/responses/Success"
+        };
+
+        #swagger.responses[401] = {
+            $ref: "#/components/responses/TokenError"
+        };
+
+        #swagger.responses[404] = {
+            $ref: "#/components/responses/RecommendationNotFoundError"
+        };
+    */
+
     try {
       const listRecomsData = await listRecomsSong(req.user.id);
       res.status(StatusCodes.OK).success(listRecomsData);


### PR DESCRIPTION
## 이슈번호 #48 

### 📌 작업한 내용  
추천 기록 리스트 조회 API Swagger 작성

---


### 🔍 참고 사항  
<404 추천 곡 및 추천 기록이 없을 때> 이 응답은 삭제할까 고민되네요.
값이 없을 땐 `{
  "success": true,
  "data": {},
  "error": null
}` 이렇게 200으로 구현하긴 했는데 혹시 몰라 다른 API도 404 응답 스웨거에 남겨두긴 했습니다.

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 
<img width="379" height="218" alt="image" src="https://github.com/user-attachments/assets/512dbce7-519f-4b49-9407-8afe63f65441" />
<img width="440" height="488" alt="image" src="https://github.com/user-attachments/assets/ded17d77-dcc6-4c2c-8347-4cdeb7ff81d5" />

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [X] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
