### PR TITLE
[FEAT] 추천 아티스트 목록 조회 API 구현

### DIFF
--- a/src/components/components.js
+++ b/src/components/components.js
@@ -1,3 +1,5 @@
+import { NotFoundArtistsError } from "../errors.js";
+
 export default {
     responses: {
         Success: {
@@ -420,6 +422,27 @@ export default {
                                 properties: {
                                     code: { type: "string", example: "U1302" },
                                     message: { type: "string", example: "커서가 잘못되었거나 접근 권한이 없습니다." },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        NotFoundArtistsError: {
+            description: "아티스트를 불러오지 못했을 때",
+            content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            success: { type: "boolean", example: false },
+                            data: { type: "object", nullable: true },
+                            error: {
+                                type: "object",
+                                properties: {
+                                    code: { type: "string", example: "A1300" },
+                                    message: { type: "string", example: "아티스트를 불러오지 못했습니다." },
                                 },
                             },
                         },

--- a/src/controllers/artists.controller.js
+++ b/src/controllers/artists.controller.js
@@ -1,0 +1,47 @@
+import { StatusCodes } from "http-status-codes";
+import { viewRecomArtists } from "../services/artists.service.js";
+import { searchItunesTracks } from "../services/spotify.service.js";
+import { NotFoundKeywordError } from "../errors.js";
+import { genAIComment } from "../services/gemini.service.js";
+
+export const handleViewRecomArtists = async (req, res, next) => {
+    /*
+    #swagger.summary = '추천 아티스트 채널 목록 조회하기';
+    
+    #swagger.responses[200] = {
+      $ref: "#/components/responses/Success"
+    };
+    
+    #swagger.responses[400] = {
+      description: "커서 오류, 아티스트나 노래 조회 오류, 쿼리 파라미터 오류",
+      content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            success: { type: "boolean", example: false },
+                            data: { type: "object", nullable: true },
+                            error: {
+                                type: "object",
+                                properties: {
+                                    code: { type: "string", example: "A1300" },
+                                    message: { type: "string", example: "아티스트를 불러올 수 없습니다." },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+      }
+
+    #swagger.responses[401] = {
+      $ref: "#/components/responses/TokenError"
+    };
+  */
+    try {
+        const list = await viewRecomArtists(req.query.sort, req.query.cursor);
+        res.status(StatusCodes.OK).success(list);
+    } catch (err) {
+        next(err);
+    }
+};

--- a/src/dtos/artists.dto.js
+++ b/src/dtos/artists.dto.js
@@ -1,0 +1,23 @@
+export const artistsResponseDTO = (data, hasNext, nextCursor) => {
+    const newData = data.map((d) => ({
+        id: d.id,
+        name: d.name,
+        imgUrl: d.img_url,
+    }));
+
+    return {
+        data: newData,
+        hasNext: hasNext,
+        nextCursor: nextCursor,
+    };
+};
+
+export const recomsArtistsResponseDTO = (data) => {
+    const newData = data.map((d) => ({
+        id: d.id,
+        name: d.name,
+        imgUrl: d.images[0].url,
+    }));
+
+    return newData;
+};

--- a/src/errors.js
+++ b/src/errors.js
@@ -120,6 +120,18 @@ export class NotSendRecomsError extends Error {
     }
 }
 
+// 도메인 : Artists
+export class NotFoundArtistsError extends Error {
+    errorCode = "A1300";
+    statusCode = 404;
+
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
 // 도메인 : Token
 // 인증 정보가 제공되어 있지 않은 경우
 export class UnauthorizedError extends Error {
@@ -160,6 +172,16 @@ export class AuthTokenError extends Error {
 // 도메인 : Spotify
 export class NotFoundSongError extends Error {
     errorCode = "S1300";
+    statusCode = 400;
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
+export class NotFoundArtistsSpotifyError extends Error {
+    errorCode = "S1301";
     statusCode = 400;
     constructor(reason, data) {
         super(reason);

--- a/src/repositories/artists.repository.js
+++ b/src/repositories/artists.repository.js
@@ -38,54 +38,6 @@ export const createSing = async (songId, artistId) => {
     });
 };
 
-// export const getArtistsByPopularity = async (decoded, limit) => {
-//     const [artists, artistInfo] = await prisma.$transaction(async (tx) => {
-//         // const grouped = await tx.userLikedArtist.groupBy({
-//         //     take: limit + 1,
-//         //     skip: decoded ? 1 : 0,
-//         //     ...(decoded && { cursor: { artistId: decoded.artistId } }),
-//         //     by: ["artistId"],
-//         //     _count: {
-//         //         artistId: true,
-//         //     },
-//         //     orderBy: [{ _count: { artistId: "desc" } }, { artistId: "asc" }],
-//         // });
-
-//         const groupByOptions = {
-//             take: limit + 1,
-//             skip: decoded ? 1 : 0,
-//             by: ["artistId"],
-//             _count: {
-//                 artistId: true,
-//             },
-//             orderBy: [{ _count: { artistId: "desc" } }, { artistId: "asc" }],
-//         };
-
-//         if (decoded?.artistId) {
-//             groupByOptions.cursor = { artistId: decoded.artistId };
-//         }
-
-//         const grouped = await tx.userLikedArtist.groupBy(groupByOptions);
-
-//         const artistIds = grouped.map((a) => a.artistId);
-
-//         const info = await tx.artist.findMany({
-//             where: {
-//                 id: {
-//                     in: artistIds,
-//                 },
-//             },
-//         });
-
-//         return [grouped, info];
-//     });
-
-//     console.log(artists);
-//     console.log(artistInfo);
-
-//     return artistInfo;
-// };
-
 export const getArtistsByPopularity = async (decoded, limit) => {
     let result;
     if (decoded) {

--- a/src/repositories/artists.repository.js
+++ b/src/repositories/artists.repository.js
@@ -5,35 +5,126 @@ export const createArtist = async (artistData) => {
         data: {
             id: artistData.id,
             name: artistData.name,
-            imgUrl: artistData.imgUrl
-        }
-    })
+            imgUrl: artistData.imgUrl,
+        },
+    });
 
     return created;
-}
+};
 
-export const getArtistById = async(artistId) => {
+export const getArtistById = async (artistId) => {
     return await prisma.artist.findUnique({
         where: {
-            id: artistId
-        }
-    })
-}
+            id: artistId,
+        },
+    });
+};
 
-export const getSing = async(recomsSongId, artistId) => {
+export const getSing = async (recomsSongId, artistId) => {
     return await prisma.sing.findFirst({
-        where:{
-            recomsSongId : recomsSongId,
-            artistId : artistId,
-        }
-    })
-}
+        where: {
+            recomsSongId: recomsSongId,
+            artistId: artistId,
+        },
+    });
+};
 
 export const createSing = async (songId, artistId) => {
     const created = await prisma.sing.create({
-        data:{
+        data: {
             recomsSongId: songId,
             artistId: artistId,
-        }
-    })
-}
+        },
+    });
+};
+
+// export const getArtistsByPopularity = async (decoded, limit) => {
+//     const [artists, artistInfo] = await prisma.$transaction(async (tx) => {
+//         // const grouped = await tx.userLikedArtist.groupBy({
+//         //     take: limit + 1,
+//         //     skip: decoded ? 1 : 0,
+//         //     ...(decoded && { cursor: { artistId: decoded.artistId } }),
+//         //     by: ["artistId"],
+//         //     _count: {
+//         //         artistId: true,
+//         //     },
+//         //     orderBy: [{ _count: { artistId: "desc" } }, { artistId: "asc" }],
+//         // });
+
+//         const groupByOptions = {
+//             take: limit + 1,
+//             skip: decoded ? 1 : 0,
+//             by: ["artistId"],
+//             _count: {
+//                 artistId: true,
+//             },
+//             orderBy: [{ _count: { artistId: "desc" } }, { artistId: "asc" }],
+//         };
+
+//         if (decoded?.artistId) {
+//             groupByOptions.cursor = { artistId: decoded.artistId };
+//         }
+
+//         const grouped = await tx.userLikedArtist.groupBy(groupByOptions);
+
+//         const artistIds = grouped.map((a) => a.artistId);
+
+//         const info = await tx.artist.findMany({
+//             where: {
+//                 id: {
+//                     in: artistIds,
+//                 },
+//             },
+//         });
+
+//         return [grouped, info];
+//     });
+
+//     console.log(artists);
+//     console.log(artistInfo);
+
+//     return artistInfo;
+// };
+
+export const getArtistsByPopularity = async (decoded, limit) => {
+    let result;
+    if (decoded) {
+        result = await prisma.$queryRaw`
+        SELECT a.*,
+            CONCAT(LPAD(likes.count::text, 10, '0'), LPAD(a.id, 30, '0')) AS cursor
+        FROM "Artist" AS a
+        JOIN (
+            SELECT artist_id, COUNT(*) AS count
+            FROM "UserLikedArtist"
+            GROUP BY artist_id
+        ) AS likes ON a.id = likes.artist_id
+        WHERE CONCAT(LPAD(likes.count::text, 10, '0'), LPAD(a.id, 30, '0')) <=
+            (
+                SELECT CONCAT(LPAD(like_count_sub.count::text, 10, '0'), LPAD(like_count_sub.artist_id, 30, '0'))
+                FROM (
+                    SELECT artist_id, COUNT(*) AS count
+                    FROM "UserLikedArtist"
+                    GROUP BY artist_id
+                ) AS like_count_sub
+                WHERE like_count_sub.artist_id = ${decoded.artistId}
+            )
+        ORDER BY likes.count DESC, a.id DESC
+        LIMIT ${limit + 1};
+    `;
+    } else {
+        result = await prisma.$queryRaw`
+        SELECT a.*,
+            CONCAT(LPAD(u.count::text, 10, '0'), LPAD(a.id, 30, '0')) AS cursor
+        FROM "Artist" AS a
+        JOIN (
+            SELECT artist_id, COUNT(*) AS count 
+            FROM "UserLikedArtist"
+            GROUP BY artist_id
+        ) AS u ON a.id = u.artist_id
+        ORDER BY u.count DESC, a.id DESC
+        LIMIT ${limit + 1};
+    `;
+    }
+
+    return result;
+};

--- a/src/routes/artists.router.js
+++ b/src/routes/artists.router.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { handleViewRecomArtists } from "../controllers/artists.controller.js";
+import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
+
+const router = Router();
+
+router.get("/recommended", handleViewRecomArtists);
+
+export default router;

--- a/src/routes/routes.index.js
+++ b/src/routes/routes.index.js
@@ -3,8 +3,9 @@ import { Router } from "express";
 // Importing the test router
 import testRouter from "./test.router.js";
 import authRouter from "./oauth.router.js";
-import recomsRouter from "./recoms.router.js"
-import usersRouter from "./users.router.js"
+import recomsRouter from "./recoms.router.js";
+import usersRouter from "./users.router.js";
+import artistsRouter from "./artists.router.js";
 
 // Importing the auth router
 const routers = Router();
@@ -13,5 +14,6 @@ routers.use("/api/v1/test", testRouter);
 routers.use("/api/v1/oauth2", authRouter);
 routers.use("/api/v1/recoms", recomsRouter);
 routers.use("/api/v1/users", usersRouter);
+routers.use("/api/v1/artists", artistsRouter);
 
 export default routers;

--- a/src/services/artists.service.js
+++ b/src/services/artists.service.js
@@ -1,0 +1,48 @@
+import { QueryParamError, CursorError, NotFoundArtistsError } from "../errors.js";
+import { getArtistsByPopularity } from "../repositories/artists.repository.js";
+import { getArtistsRandomly } from "./spotify.service.js";
+import { artistsResponseDTO, recomsArtistsResponseDTO } from "../dtos/artists.dto.js";
+
+export const viewRecomArtists = async (sort, cursor) => {
+    // 커서 오류를 잡기 위한 디코딩
+    let decoded;
+    if (cursor) {
+        try {
+            decoded = JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
+            console.log("decoded: ", decoded);
+        } catch (err) {
+            throw new CursorError("커서가 잘못되었습니다.");
+        }
+    }
+
+    if (!["popularity", "random"].includes(sort)) {
+        throw new QueryParamError("필수 쿼리 파라미터가 입력되지 않았거나 잘못된 쿼리 파라미터를 입력했습니다.");
+    }
+
+    if (sort === "popularity") {
+        // 인기순으로 아티스트 목록 조회 - 즐겨찾기 횟수 순서
+        const limit = 2;
+        let data = await getArtistsByPopularity(decoded, limit);
+
+        if (!data) {
+            throw new NotFoundArtistsError("아티스트를 불러올 수 없습니다.");
+        }
+
+        let hasNext = false;
+        let nextCursor = null;
+        if (data.length > limit) {
+            hasNext = true;
+            const nextCursorData = {
+                artistId: data[limit].id,
+            };
+            data = data.slice(0, limit);
+            nextCursor = Buffer.from(JSON.stringify(nextCursorData)).toString("base64");
+        }
+
+        return artistsResponseDTO(data, hasNext, nextCursor);
+    } else {
+        // 랜덤 아티스트 목록 조회 - 스포티파이에서 불러옴
+        const spotifyData = await getArtistsRandomly();
+        return recomsArtistsResponseDTO(spotifyData);
+    }
+};

--- a/src/services/spotify.service.js
+++ b/src/services/spotify.service.js
@@ -2,7 +2,9 @@ import axios from "axios";
 import qs from "qs";
 
 import { getSongInfoResponseDTO } from "../dtos/recoms.dto.js";
-import { NotFoundSongError, TokenError, NotFoundKeywordError } from "../errors.js";
+import { NotFoundSongError, TokenError, NotFoundKeywordError, NotFoundArtistsSpotifyError } from "../errors.js";
+import { recomsArtistsResponseDTO } from "../dtos/artists.dto.js";
+import { ckb } from "date-fns/locale";
 
 export async function searchItunesTracks(keyword, cursor = 15) {
     try {
@@ -159,4 +161,98 @@ export async function getSongInfoBySearch(artist) {
 
         throw new Error("iTunes 요청 중 알 수 없는 오류가 발생했습니다.");
     }
+}
+
+export async function getArtistsRandomly() {
+    try {
+        // 인디 노래 플레이리스트를 가져오고, 플레이리스트의 track에서 아티스트를 추출하는 구조
+        const token = await getSpotifyToken();
+        if (!token) {
+            throw new TokenError("유효하지 않은 스포티파이 토큰입니다.");
+        }
+
+        let offset;
+        let trackLimit = 20;
+        let isOverLimit = true;
+        let playlist;
+        while (isOverLimit) {
+            offset = Math.floor(Math.random() * 999);
+            playlist = await axios.get("https://api.spotify.com/v1/search", {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+
+                params: {
+                    q: "인디",
+                    type: "playlist",
+                    limit: 1,
+                    offset: offset,
+                },
+            });
+
+            //console.log(playlist.data);
+            console.log(playlist.data.playlists.items);
+
+            if (playlist.data.playlists.items[0].tracks.total >= trackLimit) {
+                isOverLimit = false;
+            }
+        }
+
+        if (!playlist) {
+            throw new NotFoundSongError("플레이리스트를 불러오지 못했습니다.");
+        }
+
+        // 트랙에서 아티스트 추출
+        let tracks = await axios.get(playlist.data.playlists.items[0].tracks.href, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+
+        if (!tracks) {
+            throw new NotFoundSongError("트랙 목록을 불러오지 못했습니다.");
+        }
+
+        let arr = getRandomIndexes(trackLimit, tracks.data.items.length);
+
+        const artistIdSet = new Set();
+        for (let i of arr) {
+            const trackArtists = tracks.data.items[i].track.artists;
+            for (let artist of trackArtists) {
+                artistIdSet.add(artist.id);
+            }
+        }
+        const artistIds = Array.from(artistIdSet);
+        console.log(artistIds);
+
+        // 아티스트 정보 불러오기
+        const response = await axios.get("https://api.spotify.com/v1/artists", {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+            params: {
+                ids: artistIds.join(","),
+            },
+        });
+
+        if (!response) {
+            throw new NotFoundArtistsSpotifyError("아티스트를 불러오지 못했습니다.");
+        }
+        return response.data.artists;
+    } catch (err) {
+        console.error("Spotify API 요청 실패:", err.response?.data || err.message);
+        throw new Error("Spotify 요청 중 알 수 없는 오류가 발생했습니다.");
+    }
+}
+
+function getRandomIndexes(limit, total) {
+    const indexes = Array.from({ length: total }, (_, i) => i);
+
+    for (let i = total - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+
+        // 구조 분해 할당을 이용한 swap
+        [indexes[i], indexes[j]] = [indexes[j], indexes[i]];
+    }
+    return indexes.slice(0, limit);
 }


### PR DESCRIPTION
## 이슈번호 #69

### 📌 작업한 내용  
추천 아티스트 목록 조회 API 구현 (랜덤, 인기순)

#### 랜덤
- spotify search api가 장르 필터링이 잘 안 되는 관계로 인디 음악 플레이리스트를 가져와서 아티스트를 추출

#### 인기순
- userLikedArtist 테이블에서 artistId를 기준으로 집계, 많은 순서대로 반환

---


### 🔍 참고 사항  
- 추천 아티스트를 랜덤으로 보여줄 때는 spotify API를 사용하기 때문에 artist 테이블에 해당 아티스트가 없을 수도 있음
- 따라서 아티스트를 즐겨찾기하는 API를 구현할 때 즐겨찾기 당한 아티스트가 artist 테이블에 있는지 먼저 확인하고 없으면 insert 해야 함

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
