### PR TITLE
[FEAT] 아티스트 즐겨찾기 API 구현

### DIFF
--- a/src/components/components.js
+++ b/src/components/components.js
@@ -450,5 +450,26 @@ export default {
                 },
             },
         },
+        DuplicateLikedArtistError: {
+            description: "아티스트를 중복으로 즐겨찾기 했을 때",
+            content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            success: { type: "boolean", example: false },
+                            data: { type: "object", nullable: true },
+                            error: {
+                                type: "object",
+                                properties: {
+                                    code: { type: "string", example: "A1200" },
+                                    message: { type: "string", example: "이미 즐겨찾기 되어 있는 아티스트입니다." },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
     },
 };

--- a/src/controllers/artists.controller.js
+++ b/src/controllers/artists.controller.js
@@ -1,8 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { viewRecomArtists } from "../services/artists.service.js";
-import { searchItunesTracks } from "../services/spotify.service.js";
-import { NotFoundKeywordError } from "../errors.js";
-import { genAIComment } from "../services/gemini.service.js";
+import { viewRecomArtists, postLikedArtists } from "../services/artists.service.js";
 
 export const handleViewRecomArtists = async (req, res, next) => {
     /*
@@ -41,6 +38,54 @@ export const handleViewRecomArtists = async (req, res, next) => {
     try {
         const list = await viewRecomArtists(req.query.sort, req.query.cursor);
         res.status(StatusCodes.OK).success(list);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const handlePostLikedArtists = async (req, res, next) => {
+    /*
+    #swagger.summary = '아티스트 즐겨찾기 하기';
+
+    #swagger.security = [{
+        bearerAuth: []
+    }]
+
+    #swagger.requestBody = {
+        required: true,
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        id: { type: "string" },
+                        name: { type: "string" },
+                        imgUrl: { type: "string" },
+                    }
+                }
+            }
+        }
+    }
+    
+    #swagger.responses[200] = {
+      $ref: "#/components/responses/Success"
+    };
+    
+    #swagger.responses[400] = {
+      $ref: "#/components/responses/RequestBodyError"
+    };
+
+    #swagger.responses[401] = {
+      $ref: "#/components/responses/TokenError"
+    };
+
+    #swagger.responses[409] = {
+      $ref: "#/components/responses/DuplicateLikedArtistError"
+    };
+  */
+    try {
+        const liked = await postLikedArtists(req.body, req.user.id);
+        res.status(StatusCodes.OK).success(liked);
     } catch (err) {
         next(err);
     }

--- a/src/dtos/artists.dto.js
+++ b/src/dtos/artists.dto.js
@@ -21,3 +21,11 @@ export const recomsArtistsResponseDTO = (data) => {
 
     return newData;
 };
+
+export const likedArtistsResponseDTO = (data) => {
+    return {
+        id: data.id,
+        artistId: data.artistId,
+        userId: data.userId,
+    };
+};

--- a/src/errors.js
+++ b/src/errors.js
@@ -143,6 +143,17 @@ export class NotFoundArtistsError extends Error {
     }
 }
 
+export class DuplicateLikedArtistError extends Error {
+    errorCode = "A1200";
+    statusCode = 409;
+
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
 // 도메인 : Token
 // 인증 정보가 제공되어 있지 않은 경우
 export class UnauthorizedError extends Error {

--- a/src/repositories/artists.repository.js
+++ b/src/repositories/artists.repository.js
@@ -80,3 +80,33 @@ export const getArtistsByPopularity = async (decoded, limit) => {
 
     return result;
 };
+
+export const createLikedArtist = async (body, userId) => {
+    const created = await prisma.userLikedArtist.create({
+        data: {
+            user: {
+                connect: {
+                    id: userId,
+                },
+            },
+            artist: {
+                connectOrCreate: {
+                    where: { id: body.id },
+                    create: {
+                        id: body.id,
+                        name: body.name,
+                        imgUrl: body.imgUrl,
+                    },
+                },
+            },
+        },
+    });
+    return created;
+};
+
+export const getUserlikedArtist = async (artistId, userId) => {
+    const liked = await prisma.userLikedArtist.findFirst({
+        where: { artistId: artistId, userId: userId },
+    });
+    return liked;
+};

--- a/src/routes/artists.router.js
+++ b/src/routes/artists.router.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
-import { handleViewRecomArtists } from "../controllers/artists.controller.js";
+import { handleViewRecomArtists, handlePostLikedArtists } from "../controllers/artists.controller.js";
 import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
 
 const router = Router();
 
 router.get("/recommended", handleViewRecomArtists);
+router.post("/liked", authenticateAccessToken, handlePostLikedArtists);
 
 export default router;


### PR DESCRIPTION
## 이슈번호 #74

### 📌 작업한 내용  
- 아티스트 즐겨찾기 API 구현
- artist 테이블에 없는 아티스트를 즐겨찾기 했을 때: artist 테이블에 아티스트 데이터 저장 후 userLikedArtist 테이블에 즐겨찾기 데이터 생성
- artist 테이블에 있는 아티스트를 즐겨찾기 했을 때: userLikedArtist 테이블에 즐겨찾기 데이터 생성 
---


### 🔍 참고 사항  


---


### 🖼️ 스크린샷  
<img width="1234" height="667" alt="image" src="https://github.com/user-attachments/assets/f1208e89-972d-4f59-a208-aa35a7868a1f" />
---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
