### PR TITLE
fix : 회원가입 / 로그인 로직 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "express-session": "^1.18.1",
                 "http-status-codes": "^2.3.0",
                 "jsonwebtoken": "^9.0.2",
+                "jwks-rsa": "^3.2.0",
                 "node-cron": "^4.2.1",
                 "nodemailer": "^7.0.5",
                 "passport": "^0.7.0",
@@ -167,6 +168,119 @@
             "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
             "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
             "hasInstallScript": true
+        },
+        "node_modules/@types/body-parser": {
+            "version": "1.19.6",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect": {
+            "version": "3.4.38",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/express": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+            "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "node_modules/@types/express-serve-static-core": {
+            "version": "4.19.6",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/jsonwebtoken": {
+            "version": "9.0.10",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+            "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/ms": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/mime": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+            "license": "MIT"
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+            "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.8.0"
+            }
+        },
+        "node_modules/@types/qs": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+            "license": "MIT"
+        },
+        "node_modules/@types/range-parser": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "license": "MIT"
+        },
+        "node_modules/@types/send": {
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+            "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/serve-static": {
+            "version": "1.15.8",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+            "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*",
+                "@types/send": "*"
+            }
         },
         "node_modules/accepts": {
             "version": "2.0.0",
@@ -1409,6 +1523,15 @@
                 "node": ">= 0.6.0"
             }
         },
+        "node_modules/jose": {
+            "version": "4.15.9",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+            "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1453,6 +1576,23 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/jwks-rsa": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.0.tgz",
+            "integrity": "sha512-PwchfHcQK/5PSydeKCs1ylNym0w/SSv8a62DgHJ//7x2ZclCoinlsjAfDxAAbpoTPybOum/Jgy+vkvMmKz89Ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/express": "^4.17.20",
+                "@types/jsonwebtoken": "^9.0.4",
+                "debug": "^4.3.4",
+                "jose": "^4.15.4",
+                "limiter": "^1.1.5",
+                "lru-memoizer": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/jws": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
@@ -1462,6 +1602,17 @@
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "node_modules/limiter": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+            "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+        },
+        "node_modules/lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+            "license": "MIT"
         },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
@@ -1504,6 +1655,28 @@
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "license": "MIT"
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/lru-memoizer": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+            "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.clonedeep": "^4.5.0",
+                "lru-cache": "6.0.0"
+            }
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
@@ -1607,6 +1780,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
             "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+            "license": "ISC",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -2589,6 +2763,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/undici-types": {
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+            "license": "MIT"
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2713,6 +2893,12 @@
             "engines": {
                 "node": ">=0.4"
             }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "express-session": "^1.18.1",
         "http-status-codes": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.2.0",
         "node-cron": "^4.2.1",
         "nodemailer": "^7.0.5",
         "passport": "^0.7.0",

--- a/src/routes/oauth.router.js
+++ b/src/routes/oauth.router.js
@@ -3,6 +3,6 @@ import { handleKakaoLogin } from "../controllers/oauth.controllers.js"
 
 const router = Router();
 
-router.get("/callback/kakao", handleKakaoLogin);
+router.post("/callback/kakao", handleKakaoLogin);
 
 export default router;


### PR DESCRIPTION
## 이슈번호 #72 <!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
카카오톡 소셜 로그인 로직 변경

---


### 🔍 참고 사항  
[ 기존 로직 ]
1. 프론트에서 인가코드를 파라미터로 받음
2. 인가코드로 카카오에서 accessToken 발급
3. accessToken 이용하여 카카오에서 사용자 정보 가져오기
4. 가져온 정보들로 DB에 저장

[ 현재 로직 ]
프론트에서 인가코드로 accessToken, id_token 발급
1. 프론트에서 Id_token을 body로 전달해줌
2. id_token으로 카카오에서 사용자 정보 가져오기
3. 가져온 사용자 정보들로 DB에 저장

---


### 🖼️ 스크린샷  
<img width="940" height="269" alt="image" src="https://github.com/user-attachments/assets/1c3b5866-c231-41e3-8ac2-dbce4a6fa6d6" />

성공했는데, 성공 후 응답 객체에 토큰이 포함되어있어서 잘랐습니당 ㅎㅎ 

---

### 🔗 관련 이슈  
카카오 하나로도 힘들다는 프론트 측의 의견을 반영하여 네이버와 구글 로그인은 없앴습ㄴㅣ다 ...

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
