### PR TITLE
[FIX] 추천 아티스트 목록 조회 에러 해결

### DIFF
--- a/src/cron/scheduler.js
+++ b/src/cron/scheduler.js
@@ -13,11 +13,11 @@ export const songScheduler = async () => {
     cron.schedule("* * * * *", async () => {
         try {
             let min = new Date().getMinutes();
-            console.log(`running a task every minute: ${min}`);
+            //console.log(`running a task every minute: ${min}`);
             const recomsList = await getRecomsWithNoReceiver();
-            console.log("recomsList: ", recomsList);
+            //console.log("recomsList: ", recomsList);
             const userList = await getUserList();
-            console.log("userList: ", userList);
+            //console.log("userList: ", userList);
             let i = 0;
 
             for (let user of userList) {
@@ -25,34 +25,34 @@ export const songScheduler = async () => {
 
                 // 노래를 보내지 않았을 경우
                 if (!isSent) {
-                    console.log("노래를 추천하지 않았습니다: ", user.id);
+                    //console.log("노래를 추천하지 않았습니다: ", user.id);
                     continue;
                 }
 
                 if (!recomsList[i]) {
                     // 보낼 추천 곡이 없는 경우 - AI 생성
-                    console.log("AI로 노래를 생성합니다.");
+                    //console.log("AI로 노래를 생성합니다.");
                     await sendAIRecoms(user.id);
-                    console.log("AI 노래 생성 완료!");
+                    //console.log("AI 노래 생성 완료!");
                 } else if (user.id === recomsList.senderId) {
                     // 본인이 보낸 추천 곡을 추천 받았을 경우
-                    console.log("본인이 보낸 추천 곡을 추천 받았습니다.");
+                    //console.log("본인이 보낸 추천 곡을 추천 받았습니다.");
                     i++;
                     if (!recomsList[i]) {
-                        console.log("다음 리스트가 없습니다. AI로 노래를 생성합니다.");
+                        //console.log("다음 리스트가 없습니다. AI로 노래를 생성합니다.");
                         await sendAIRecoms(user.id);
-                        console.log("AI 노래 생성 완료!");
+                        //console.log("AI 노래 생성 완료!");
                     } else {
-                        console.log(`다음 리스트가 있습니다. ${i}번째: `, recomsList[i]);
+                        //console.log(`다음 리스트가 있습니다. ${i}번째: `, recomsList[i]);
                         await sendUserRecoms();
-                        console.log("receiver 등록 완료!: ", user.id);
+                        //console.log("receiver 등록 완료!: ", user.id);
                         i++;
                     }
                 } else {
                     // 보낼 추천 곡이 있고 sender가 본인이 아닌 경우
-                    console.log(`다음 리스트가 있습니다. ${i}번째: `, recomsList[i]);
+                    //console.log(`다음 리스트가 있습니다. ${i}번째: `, recomsList[i]);
                     await sendUserRecoms(recomsList[i].id, user.id);
-                    console.log("receiver 등록 완료!");
+                    //console.log("receiver 등록 완료!");
                     i++;
                 }
 

--- a/src/dtos/artists.dto.js
+++ b/src/dtos/artists.dto.js
@@ -16,7 +16,7 @@ export const recomsArtistsResponseDTO = (data) => {
     const newData = data.map((d) => ({
         id: d.id,
         name: d.name,
-        imgUrl: d.images[0].url,
+        imgUrl: d.images?.[0]?.url || null,
     }));
 
     return newData;

--- a/src/services/artists.service.js
+++ b/src/services/artists.service.js
@@ -15,7 +15,7 @@ export const viewRecomArtists = async (sort, cursor) => {
     if (cursor) {
         try {
             decoded = JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
-            console.log("decoded: ", decoded);
+            //console.log("decoded: ", decoded);
         } catch (err) {
             throw new CursorError("커서가 잘못되었습니다.");
         }

--- a/src/services/spotify.service.js
+++ b/src/services/spotify.service.js
@@ -191,9 +191,9 @@ export async function getArtistsRandomly() {
             });
 
             //console.log(playlist.data);
-            console.log(playlist.data.playlists.items);
-
-            if (playlist.data.playlists.items[0].tracks.total >= trackLimit) {
+            //console.log(playlist.data.playlists.items);
+            const items = playlist.data.playlists.items;
+            if (items.length > 0 && items[0].tracks.total >= trackLimit) {
                 isOverLimit = false;
             }
         }


### PR DESCRIPTION
## 이슈번호 #81

### 📌 작업한 내용  
- 추천 아티스트 목록 랜덤 조회 시 500 에러 -> spotify API 응답에서 tracks가 없으면 다시 요청, imgUrl이 없는 경우 null로 처리
- 추천 아티스트 목록 인기순 조회 로직 변경 -> 즐겨찾기가 안 된 아티스트도 조회가 될 수 있도록 변경
- cron 스케줄러 디버깅용 코드 주석 처리

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
