### PR TITLE
[REFACTOR] 마이페이지 조회 API 통합

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,10 +15,8 @@ model UserLikedArtist {
   userId         String    @map("user_id")
   inactiveAt     DateTime? @map("inactive_at")
   inactiveStatus Boolean   @default(false) @map("inactive_status")
-  artist         Artist    @relation(fields: [artistId], references: [id])
   user           User      @relation(fields: [userId], references: [id])
-
-  @@map("user_liked_artist")
+  artist         Artist    @relation(fields: [artistId], references: [id])
 }
 
 model Inquiry {
@@ -28,8 +26,6 @@ model Inquiry {
   updatedAt DateTime @updatedAt @map("updated_at")
   content   String
   name      String
-
-  @@map("inquiry")
 }
 
 model RecomsSong {
@@ -40,8 +36,6 @@ model RecomsSong {
   previewUrl      String?          @map("preview_url")
   sings           Sing[]
   userRecomsSongs UserRecomsSong[]
-
-  @@map("recoms_song")
 }
 
 model Sing {
@@ -50,8 +44,6 @@ model Sing {
   artistId     String     @map("artist_id")
   artist       Artist     @relation(fields: [artistId], references: [id])
   recomsSong   RecomsSong @relation(fields: [recomsSongId], references: [id])
-
-  @@map("sing")
 }
 
 model Artist {
@@ -60,23 +52,21 @@ model Artist {
   imgUrl          String?           @map("img_url")
   sings           Sing[]
   userLikedArtist UserLikedArtist[]
-
-  @@map("artist")
 }
 
 model Notification {
   id          String     @id @unique @default(uuid())
   createdAt   DateTime   @default(now()) @map("created_at")
   updatedAt   DateTime   @updatedAt @map("updated_at")
+  referenceId String     @map("reference_id")
   receiverId  String     @map("receiver_id")
+  content     String
   isConfirmed Boolean    @default(false) @map("is_confirmed")
   link        String?
   senderId    String?    @map("sender_id")
   type        NoticeType
   receiver    User       @relation("NotificationReceiver", fields: [receiverId], references: [id])
   sender      User?      @relation("NotificationSender", fields: [senderId], references: [id])
-
-  @@map("notification")
 }
 
 model RecomsReply {
@@ -88,8 +78,6 @@ model RecomsReply {
   responderId      String         @map("responder_id")
   responder        User           @relation(fields: [responderId], references: [id])
   userRecomsSong   UserRecomsSong @relation(fields: [userRecomsSongId], references: [id])
-
-  @@map("recoms_reply")
 }
 
 model UserRecomsSong {
@@ -105,8 +93,6 @@ model UserRecomsSong {
   receiver     User?        @relation("UserReceivedRecom", fields: [receiverId], references: [id])
   recomsSong   RecomsSong   @relation(fields: [recomsSongId], references: [id])
   sender       User         @relation("UserSentRecom", fields: [senderId], references: [id])
-
-  @@map("user_recoms_song")
 }
 
 model User {
@@ -127,7 +113,6 @@ model User {
   email           String
   name            String
   isDelivered     Boolean           @default(false) @map("is_delivered")
-  refreshToken    String?           @map("refresh_token")
   fcmTokens       FcmToken[]
   receivedNotices Notification[]    @relation("NotificationReceiver")
   sentNotices     Notification[]    @relation("NotificationSender")
@@ -138,7 +123,6 @@ model User {
   sentRecoms      UserRecomsSong[]  @relation("UserSentRecom")
 
   @@index([isDelivered, recomsTime])
-  @@map("user")
 }
 
 model FcmToken {
@@ -147,8 +131,6 @@ model FcmToken {
   userId    String   @map("user_id")
   createdAt DateTime @default(now()) @map("created_at")
   user      User     @relation(fields: [userId], references: [id])
-
-  @@map("fcm_token")
 }
 
 model Session {
@@ -169,11 +151,9 @@ model NotificationType {
   notRecoms      Boolean @default(true) @map("not_recoms")
   announcement   Boolean @default(true)
   user           User    @relation(fields: [userId], references: [id])
-
-  @@map("notification_type")
 }
 
-enum Gender {
+enum gender {
   MAN
   WOMAN
 
@@ -184,8 +164,6 @@ enum SocialType {
   NAVER
   KAKAO
   GOOGLE
-
-  @@map("social_type")
 }
 
 enum NoticeType {
@@ -196,4 +174,10 @@ enum NoticeType {
   ANNOUNCEMENT
 
   @@map("notice_type")
+}
+
+enum social_type {
+  NAVER
+  KAKAO
+  GOOGLE
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,8 +15,10 @@ model UserLikedArtist {
   userId         String    @map("user_id")
   inactiveAt     DateTime? @map("inactive_at")
   inactiveStatus Boolean   @default(false) @map("inactive_status")
-  user           User      @relation(fields: [userId], references: [id])
   artist         Artist    @relation(fields: [artistId], references: [id])
+  user           User      @relation(fields: [userId], references: [id])
+
+  @@map("user_liked_artist")
 }
 
 model Inquiry {
@@ -26,6 +28,8 @@ model Inquiry {
   updatedAt DateTime @updatedAt @map("updated_at")
   content   String
   name      String
+
+  @@map("inquiry")
 }
 
 model RecomsSong {
@@ -36,6 +40,8 @@ model RecomsSong {
   previewUrl      String?          @map("preview_url")
   sings           Sing[]
   userRecomsSongs UserRecomsSong[]
+
+  @@map("recoms_song")
 }
 
 model Sing {
@@ -44,6 +50,8 @@ model Sing {
   artistId     String     @map("artist_id")
   artist       Artist     @relation(fields: [artistId], references: [id])
   recomsSong   RecomsSong @relation(fields: [recomsSongId], references: [id])
+
+  @@map("sing")
 }
 
 model Artist {
@@ -52,21 +60,23 @@ model Artist {
   imgUrl          String?           @map("img_url")
   sings           Sing[]
   userLikedArtist UserLikedArtist[]
+
+  @@map("artist")
 }
 
 model Notification {
   id          String     @id @unique @default(uuid())
   createdAt   DateTime   @default(now()) @map("created_at")
   updatedAt   DateTime   @updatedAt @map("updated_at")
-  referenceId String     @map("reference_id")
   receiverId  String     @map("receiver_id")
-  content     String
   isConfirmed Boolean    @default(false) @map("is_confirmed")
   link        String?
   senderId    String?    @map("sender_id")
   type        NoticeType
   receiver    User       @relation("NotificationReceiver", fields: [receiverId], references: [id])
   sender      User?      @relation("NotificationSender", fields: [senderId], references: [id])
+
+  @@map("notification")
 }
 
 model RecomsReply {
@@ -78,6 +88,8 @@ model RecomsReply {
   responderId      String         @map("responder_id")
   responder        User           @relation(fields: [responderId], references: [id])
   userRecomsSong   UserRecomsSong @relation(fields: [userRecomsSongId], references: [id])
+
+  @@map("recoms_reply")
 }
 
 model UserRecomsSong {
@@ -93,6 +105,8 @@ model UserRecomsSong {
   receiver     User?        @relation("UserReceivedRecom", fields: [receiverId], references: [id])
   recomsSong   RecomsSong   @relation(fields: [recomsSongId], references: [id])
   sender       User         @relation("UserSentRecom", fields: [senderId], references: [id])
+
+  @@map("user_recoms_song")
 }
 
 model User {
@@ -113,6 +127,7 @@ model User {
   email           String
   name            String
   isDelivered     Boolean           @default(false) @map("is_delivered")
+  refreshToken    String?           @map("refresh_token")
   fcmTokens       FcmToken[]
   receivedNotices Notification[]    @relation("NotificationReceiver")
   sentNotices     Notification[]    @relation("NotificationSender")
@@ -123,6 +138,7 @@ model User {
   sentRecoms      UserRecomsSong[]  @relation("UserSentRecom")
 
   @@index([isDelivered, recomsTime])
+  @@map("user")
 }
 
 model FcmToken {
@@ -131,6 +147,8 @@ model FcmToken {
   userId    String   @map("user_id")
   createdAt DateTime @default(now()) @map("created_at")
   user      User     @relation(fields: [userId], references: [id])
+
+  @@map("fcm_token")
 }
 
 model Session {
@@ -151,9 +169,11 @@ model NotificationType {
   notRecoms      Boolean @default(true) @map("not_recoms")
   announcement   Boolean @default(true)
   user           User    @relation(fields: [userId], references: [id])
+
+  @@map("notification_type")
 }
 
-enum gender {
+enum Gender {
   MAN
   WOMAN
 
@@ -164,6 +184,8 @@ enum SocialType {
   NAVER
   KAKAO
   GOOGLE
+
+  @@map("social_type")
 }
 
 enum NoticeType {
@@ -174,10 +196,4 @@ enum NoticeType {
   ANNOUNCEMENT
 
   @@map("notice_type")
-}
-
-enum social_type {
-  NAVER
-  KAKAO
-  GOOGLE
 }

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -175,7 +175,7 @@ export const handleViewMyPage = async (req, res, next) => {
     */
 
     try {
-        const mypage = await viewMyPage(req.user.id);
+        const mypage = await viewMyPage(req.user.id, req.params.ownId);
         res.status(StatusCodes.OK).success(mypage);
     } catch (err) {
         next(err);

--- a/src/errors.js
+++ b/src/errors.js
@@ -53,6 +53,17 @@ export class AuthorizationCodeError extends Error {
     }
 }
 
+export class NotFoundOwnIdError extends Error {
+     errorCode = "U1303";
+    statusCode = 404;
+
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
 // 도메인 : Recoms
 export class InvalidRecomsTimeError extends Error {
     errorCode = "R1000";

--- a/src/routes/users.router.js
+++ b/src/routes/users.router.js
@@ -15,6 +15,6 @@ router.patch("/me/profiles", authenticateAccessToken, handleModifyUserInfo);
 router.get("/me/notification", authenticateAccessToken, handleViewNotification);
 router.post("/inquiry", handleInquiry);
 router.get("/me/notification", authenticateAccessToken, handleViewNotification);
-router.get("/me", authenticateAccessToken, handleViewMyPage);
+router.get("/:ownId", authenticateAccessToken, handleViewMyPage);
 
 export default router;

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -5,6 +5,7 @@ import {
     InvalidRecomsTimeError,
     CursorError,
     AuthError,
+    NotFoundOwnIdError,
 } from "../errors.js";
 import { getUserById, getUserByOwnId, modifyUser, getNotification } from "../repositories/users.repository.js";
 import { notificationResponseDTO, getMyPageResponseDTO } from "../dtos/users.dto.js";
@@ -110,11 +111,19 @@ export const viewNotification = async (userId, cursor) => {
     return notificationResponseDTO(data, hasNext, nextCursor);
 };
 
-export const viewMyPage = async (userId) => {
+export const viewMyPage = async (userId, ownId) => {
     const user = await getUserById(userId);
-        if (!user) {
-        throw new NoUserError("존재하지 않는 사용자 ID입니다.");
+    const other = await getUserByOwnId(ownId);  
+
+    if (!other) 
+    {
+        throw new NotFoundOwnIdError("존재하지 않는 사용자입니다.")
     }
-    
-    return getMyPageResponseDTO(user);
+
+    if (user.ownId === other.ownId) {
+        return getMyPageResponseDTO(user);
+    }
+    else {  
+        return getMyPageResponseDTO(other);
+    }
 };


### PR DESCRIPTION
## 이슈번호 #86 

### 📌 작업한 내용  
내 마이페이지를 조회하는 API와 타 유저 마이페이지를 조회하는 API를 분리하려고 했으나, 
하나로 합치는 것이 가능하여 통합하였다.
엔드포인트를 api/v1/users/{ownId}로 변경하여 사용자 Id로 접근할 수 있게 하였다.

---


### 🔍 참고 사항  
스키마 잘못 올라갔어요...

---


### 🖼️ 스크린샷  
### 내가 나의 마이페이지를 조회하는 경우
<img width="322" height="170" alt="200" src="https://github.com/user-attachments/assets/baf65483-faff-4725-ac9e-10360bcca040" /> <br>
### 다른 유저의 마이페이지를 조회하는 경우
<img width="299" height="169" alt="타 유저 마이페이지 방문" src="https://github.com/user-attachments/assets/ad1a8f02-f171-46f8-95e7-9ebc7a81120a" /> <br>
### 없는 사용자 아이디로 조회하는 경우
<img width="332" height="162" alt="없는 ownId일 경우" src="https://github.com/user-attachments/assets/534b1872-d6a9-48ad-abd3-8c5a35a7dbf4" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인

