### PR TITLE
[REFACTOR] 추천 기록 캘린더 말일 조회 오류 해결

### DIFF
--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -172,9 +172,8 @@ export const patchLikeStatus = async (recomsId, userId, isLiked) => {
 };
 
 export const getCalendarRecomsSong = async (userId, year, month, status) => {
-    const startDate = new Date(`${year}-${month}-01`);
-    const endDate = new Date(startDate);
-    endDate.setMonth(endDate.getMonth() + 1);
+    const startDate = new Date(Date.UTC(year, month - 1, 1, -9)); 
+    const endDate = new Date(Date.UTC(year, month, 1, -9));       
 
     const whereClause = {
         createdAt: {


### PR DESCRIPTION
## 이슈번호 #90 

### 📌 작업한 내용  
이전 코드는 해당 달 범위를 잘 설정해줬지만,
UTC 기준: 2025-07-31T15:30:00Z의 경우 2025년 8월 1일 00:30 (KST)인데 7월 캘린더에 노출되는 현상이 발견됨.

해결방법 : startDate, endDate를 KST 기준으로 보정해서 생성함.

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

---


### 🖼️ 스크린샷  
### 내가 7월에 보낸 추천곡
<img width="921" height="340" alt="image" src="https://github.com/user-attachments/assets/22cd21aa-d267-410d-9973-8a00f2ebbfc8" /> <br>
### 내가 8월에 보낸 추천곡
<img width="917" height="230" alt="image" src="https://github.com/user-attachments/assets/25c5f4f4-d257-4da5-bb35-afe04ae898bd" /> <br>
### 내가 7월에 받은 추천곡
<img width="932" height="370" alt="image" src="https://github.com/user-attachments/assets/ceb33d62-5cf6-44dc-83b0-ae2571c25cae" /> <br>

### 내가 8월에 받은 추천곡
<img width="932" height="368" alt="image" src="https://github.com/user-attachments/assets/3db5b990-19e1-448f-9c75-7f4d1f535b1d" />

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
