### PR TITLE
[FEAT] 리프레시 토큰 발급 로직 추가

### DIFF
--- a/src/controllers/oauth.controllers.js
+++ b/src/controllers/oauth.controllers.js
@@ -1,16 +1,23 @@
-import { AuthorizationCodeError, TokenError } from "../errors.js";
-import { generateToken } from "../utils/token.js";
+import { AuthTokenError, TokenError } from "../errors.js";
+import { generateRefreshToken, generateToken } from "../utils/token.js";
 import { getKakaoUser } from "../configs/auth.config.js"
-import { findOrCreateUser } from "../repositories/users.repository.js"
+import { findOrCreateUser, findUserByToken } from "../repositories/users.repository.js"
+import { updateUserRefreshToken } from "../repositories/users.repository.js";
 import pkg from '@prisma/client';
 import { StatusCodes } from "http-status-codes";
 const { SocialType } = pkg;
+import jwt from 'jsonwebtoken';
+
 
 export const handleKakaoLogin = async (req, res, next) => {
     /*
     #swagger.summary = '카카오톡 소셜 로그인 API';
     #swagger.responses[200] = {
         $ref: "#/components/responses/Success"
+    };
+
+    #swagger.responses[401] = {
+      $ref: "#/components/responses/TokenError"
     };
     */
    try{
@@ -28,10 +35,48 @@ export const handleKakaoLogin = async (req, res, next) => {
     const user = await findOrCreateUser(name, email, SocialType.KAKAO);
 
     const token = generateToken({id: user.id});
+    const refreshToken = generateRefreshToken({id : user.id})
 
-    res.status(StatusCodes.OK).success({token, user});
+    await updateUserRefreshToken(user.id, refreshToken);
+
+    res.status(StatusCodes.OK).success({token,refreshToken, user});
    } catch (err) {
     console.error("Kakao 로그인 실패", err);
-    res.status(500).json({ message: "Kakao 로그인 실패" });
+    res.status(500).json({ code: 500, message: `카카오 로그인 실패 ${err}` });
   }
 }
+
+export const handleRefreshAccessToken = async (req, res) => {
+   /*
+    #swagger.summary = 'AccessToken 재발급 API';
+    #swagger.responses[200] = {
+        $ref: "#/components/responses/Success"
+    };
+
+    #swagger.responses[401] = {
+      $ref: "#/components/responses/TokenError"
+    };
+
+    #swagger.responses[403] = {
+      $ref: "#/components/responses/AuthError"
+    };
+    */
+
+  const { refreshToken } = req.body;
+  if (!refreshToken) throw new TokenError("리프레시 토큰이 전달되지 않았습니다");
+
+  try {
+    const decoded = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET);
+    console.log(decoded);
+    const user = await findUserByToken(decoded.id);
+
+    if (!user || user.refreshToken !== refreshToken) {
+      throw new AuthTokenError("유효하지 않은 토큰입니다");
+    }
+
+    const newAccessToken = generateToken({ id: user.id });
+    res.status(200).json({ token: newAccessToken });
+  } catch (err) {
+    res.status(500).json({ code: 500, message: `AccessToken 재발급 실패 ${err}` });
+  }
+};

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -82,3 +82,17 @@ export const getNotification = async (userId, decoded, limit) => {
     });
     return notification;
 };
+
+export const updateUserRefreshToken = async (userId, refreshToken) => {
+    return await prisma.user.update({
+        where: { id: userId },
+        data: { refreshToken },
+    });
+  
+}
+
+export const findUserByToken = async (id) => {
+    return await prisma.user.findUnique({ 
+        where: { id: id } 
+    });
+}

--- a/src/routes/oauth.router.js
+++ b/src/routes/oauth.router.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
-import { handleKakaoLogin } from "../controllers/oauth.controllers.js"
+import { handleKakaoLogin, handleRefreshAccessToken } from "../controllers/oauth.controllers.js"
 
 const router = Router();
 
 router.post("/callback/kakao", handleKakaoLogin);
+router.patch("/refresh/token", handleRefreshAccessToken);
 
 export default router;

--- a/src/services/recoms.service.js
+++ b/src/services/recoms.service.js
@@ -98,8 +98,9 @@ export const addRecoms = async (data, userId) => {
     }
     console.log(artists);
 
+    let singData = null;
     for (const artist of artists) {
-        let singData = await getSing(recomsSong.id, artist.id);
+        singData = await getSing(recomsSong.id, artist.id);
         if (!singData) {
             singData = await createSing(recomsSong.id, artist.id);
         }

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -5,3 +5,9 @@ export const generateToken = (payload) => {
     expiresIn: process.env.JWT_EXPIRES_IN || '1h',
   });
 };
+
+export const generateRefreshToken = (payload) => {
+  return jwt.sign(payload, process.env.JWT_REFRESH_SECRET, {
+    expiresIn: process.env.JWT_REFRESH_EXPIRES_IN,
+  });
+};


### PR DESCRIPTION
## 이슈번호 #72 <!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
이 PR에서 변경된 내용을 간략히 작성해주세요.
- 리프레시 토큰 발급하는 로직을 추가했습니다.

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.
- 회원가입시 어세스토큰, 리프레시 토큰 모두 발급하여 리프레시 토큰은 DB에 저장하고, 어세슨토큰&리프레시 토큰 모두 클라이언트에게 전송
- 어세스 토큰 만료시, 토큰을 재발급하는 api를 통해 리프레시 토큰으로 어세스 토큰을 재발급
---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 
- 회원가입
  <img width="642" height="837" alt="image" src="https://github.com/user-attachments/assets/7cfb431f-12fa-43e6-867a-a967c5f6d4d1" />
- 토큰 재발급
  <img width="635" height="604" alt="image" src="https://github.com/user-attachments/assets/382f1e0a-c4d2-4480-889d-8c45409f6f86" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
