### PR TITLE
[REFACTOR] iTunes에서 불러오는 앨범 이미지의 화질 개선

### DIFF
--- a/src/dtos/recoms.dto.js
+++ b/src/dtos/recoms.dto.js
@@ -64,12 +64,14 @@ export const searchRecomsResponseDTO = (recom, isReceived = false) => {
 };
 
 export const getSongInfoResponseDTO = (songData) => {
+    const highResAlbumImg = songData.artworkUrl100.replace(/\/[0-9]+x[0-9]+bb\.jpg$/, "/1000x1000bb.jpg");
+
     return {
         id: songData.trackId.toString(),
         title: songData.trackName,
         artist: songData.artistName,
         album: songData.collectionName,
-        albumImg: songData.artworkUrl100,
+        albumImg: highResAlbumImg,
         previewUrl: songData.previewUrl,
     };
 };


### PR DESCRIPTION
## 이슈번호 #99 <!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
이 PR에서 변경된 내용을 간략히 작성해주세요.
iTunes에서 불러오는 앨범 이미지의 크기를 1000x1000으로 변경하여 가져옴

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.
iTunes에서 불러오는 데이터에는 20x20, 30x30, 100x100 크기 밖에 없어서 기존에는 그나마 가장 큰 100x100 크기의 이미지를 불러오도록 하였는데, 프론트쪽에서 1000x1000 크기의 이미지도 지원한다는 사실을 알려주어 100x100 크기의 이미지를 직접 1000x1000 크기의 이미지로 변경하는 코드를 작성했습니다. 


---


### 🖼️ 스크린샷  
<img width="765" height="38" alt="image" src="https://github.com/user-attachments/assets/c996138b-e12c-4f37-b4d4-8def712db023" />
<img width="806" height="439" alt="image" src="https://github.com/user-attachments/assets/244498cb-b3b2-49ef-9cf3-4a704c9f1e6b" />


---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
