### PR TITLE
[REFACTOR] 추천 곡 자동 발신 과정에 redis 캐시 적용

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,8 @@ model UserRecomsSong {
   isAnoymous   Boolean      @default(false) @map("is_anoymous")
   isLiked      Boolean?     @map("is_liked")
   comment      String
+  isRead       Boolean      @default(false) @map("is_read")
+  updatedAt    DateTime?    @updatedAt @map("updated_at")
   replies      RecomsReply?
   receiver     User?        @relation("UserReceivedRecom", fields: [receiverId], references: [id])
   recomsSong   RecomsSong   @relation(fields: [recomsSongId], references: [id])
@@ -119,7 +121,7 @@ model User {
   photo           String?
   bio             String?
   createdAt       DateTime          @default(now()) @map("created_at")
-  updatedAt       DateTime          @updatedAt @map("updated_at")
+  updatedAt       DateTime?         @updatedAt @map("updated_at")
   inactiveAt      DateTime?         @map("inactive_at")
   inactiveStatus  Boolean           @default(false) @map("inactive_status")
   backgroundImg   String?           @map("background_img")
@@ -128,8 +130,7 @@ model User {
   email           String
   name            String
   isDelivered     Boolean           @default(false) @map("is_delivered")
-  refreshToken    String?           @map("refresh_token")
-  fcmTokens       FcmToken[]
+  expoPushTokens  ExpoPushToken[]
   receivedNotices Notification[]    @relation("NotificationReceiver")
   sentNotices     Notification[]    @relation("NotificationSender")
   notifications   NotificationType?
@@ -142,14 +143,14 @@ model User {
   @@map("user")
 }
 
-model FcmToken {
+model ExpoPushToken {
   id        String   @id @unique @default(uuid())
-  fcmToken  String   @map("fcm_token") @db.VarChar(512)
+  token     String
   userId    String   @map("user_id")
   createdAt DateTime @default(now()) @map("created_at")
   user      User     @relation(fields: [userId], references: [id])
 
-  @@map("fcm_token")
+  @@map("expo_push_token")
 }
 
 model Session {

--- a/src/cron/scheduler.js
+++ b/src/cron/scheduler.js
@@ -29,7 +29,6 @@ export const songScheduler = async () => {
 
                 // 노래를 보내지 않았을 경우
                 if (!isSent) {
-                    //console.log("노래를 추천하지 않았습니다: ", user.id);
                     continue;
                 }
 
@@ -37,6 +36,10 @@ export const songScheduler = async () => {
                 if (recoms) {
                     // 보낼 추천 곡이 있는 경우 - 추천 곡 리스트에서 곡을 반환
                     await sendUserRecoms(recoms.id, user);
+                    const idx = recomsList.findIndex((r) => r.id === recoms.id);
+                    if (idx !== -1) {
+                        recomsList.splice(idx, 1);
+                    }
                     //console.log("receiver 등록 완료!");
                 } else {
                     // 보낼 추천 곡이 없는 경우 - AI 생성
@@ -65,7 +68,7 @@ export const resetIsDeliveredScheduler = async () => {
 
                 if (userIds.length > 0) {
                     for (const id of userIds) {
-                        const result = await redisClient.sAdd("user:isDeliveredFalse", id);
+                        await redisClient.sAdd("user:isDeliveredFalse", id);
                     }
                 }
             } catch (err) {

--- a/src/cron/scheduler.js
+++ b/src/cron/scheduler.js
@@ -1,24 +1,31 @@
 import { sendAIRecoms, sendUserRecoms } from "../services/recoms.service.js";
-import {
-    getRecomsWithNoReceiver,
-    getUserList,
-    getSenderToday,
-    updateIsDeliveredToFalse,
-} from "../repositories/recoms.repository.js";
+import { updateIsDeliveredToFalse } from "../repositories/recoms.repository.js";
 import { deleteUserLikedArtists } from "../repositories/artists.repository.js";
 import cron from "node-cron";
 import { SchedulerError } from "../errors.js";
+import redisClient from "../utils/redis.js";
 
 export const songScheduler = async () => {
     cron.schedule("* * * * *", async () => {
         try {
-            const recomsList = await getRecomsWithNoReceiver();
+            let recomsList = [];
+            let keys = await redisClient.keys("*userRecomsSong*");
+            //console.log(keys);
+
+            if (keys.length > 0) {
+                for (let i = 0; i < keys.length; i++) {
+                    const key = keys[i];
+                    const value = await redisClient.get(key);
+                    recomsList.push(JSON.parse(value));
+                }
+            }
             //console.log("recomsList: ", recomsList);
-            const userList = await getUserList();
+
+            let userList = await redisClient.sMembers("user:isDeliveredFalse");
             //console.log("userList: ", userList);
 
             for (let user of userList) {
-                const isSent = await getSenderToday(user.id);
+                let isSent = await redisClient.get(`userRecomsSongData:user:${user}`);
 
                 // 노래를 보내지 않았을 경우
                 if (!isSent) {
@@ -26,15 +33,15 @@ export const songScheduler = async () => {
                     continue;
                 }
 
-                const recoms = recomsList.find((r) => r.senderId !== user.id);
+                const recoms = recomsList.find((r) => r.senderId !== user);
                 if (recoms) {
                     // 보낼 추천 곡이 있는 경우 - 추천 곡 리스트에서 곡을 반환
-                    await sendUserRecoms(recoms.id, user.id);
+                    await sendUserRecoms(recoms.id, user);
                     //console.log("receiver 등록 완료!");
                 } else {
                     // 보낼 추천 곡이 없는 경우 - AI 생성
                     //console.log("AI로 노래를 생성합니다.");
-                    await sendAIRecoms(user.id);
+                    await sendAIRecoms(user);
                     //console.log("AI 노래 생성 완료!");
                 }
 
@@ -52,9 +59,15 @@ export const resetIsDeliveredScheduler = async () => {
         "0 0 * * *",
         async () => {
             try {
-                const updated = await updateIsDeliveredToFalse();
-                console.log("업데이트 된 행의 개수: ", updated);
-                console.log(new Date());
+                await redisClient.del("user:isDeliveredFalse");
+
+                const userIds = await updateIsDeliveredToFalse();
+
+                if (userIds.length > 0) {
+                    for (const id of userIds) {
+                        const result = await redisClient.sAdd("user:isDeliveredFalse", id);
+                    }
+                }
             } catch (err) {
                 console.error(`resetIsDeliveredScheduler error: ${err}`);
                 throw new SchedulerError(

--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -321,7 +321,7 @@ export const updateIsDeliveredToFalse = async () => {
 
         const userIds = users.map((u) => u.id);
 
-        await tx.user.updateMany({
+        const updatedCount = await tx.user.updateMany({
             where: { id: { in: userIds } },
             data: { isDelivered: false },
         });

--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -247,50 +247,6 @@ export const createReply = async (recomsId, userId, content) => {
     return created;
 };
 
-export const getUserList = async () => {
-    let now = new Date();
-    let hour = now.getHours();
-    let min = now.getMinutes();
-
-    if (hour < 10) {
-        hour = "0" + hour.toString();
-    } else {
-        hour = hour.toString();
-    }
-
-    if (min < 10) {
-        min = "0" + min.toString();
-    } else {
-        min = min.toString();
-    }
-    let time = hour + min;
-
-    const userList = await prisma.user.findMany({
-        where: {
-            isDelivered: false,
-            recomsTime: {
-                lt: time,
-            },
-            inactiveStatus: false,
-        },
-        select: {
-            id: true,
-        },
-    });
-    return userList;
-};
-
-export const getRecomsWithNoReceiver = async () => {
-    const recomsList = await prisma.userRecomsSong.findMany({
-        where: { receiverId: null },
-        select: {
-            id: true,
-            senderId: true,
-        },
-    });
-    return recomsList;
-};
-
 export const updateReceiver = async (recomsId, userId) => {
     const receiverUpdate = await prisma.userRecomsSong.update({
         where: { id: recomsId, NOT: { senderId: userId } },
@@ -356,11 +312,22 @@ export const updateIsDeliveredToTrue = async (userId) => {
 };
 
 export const updateIsDeliveredToFalse = async () => {
-    const updated = await prisma.user.updateMany({
-        where: { NOT: { id: "AI" } },
-        data: {
-            isDelivered: false,
-        },
+    // userId를 가져오기 위해 findMany() 추가
+    const result = await prisma.$transaction(async (tx) => {
+        const users = await tx.user.findMany({
+            where: { inactiveStatus: false, NOT: { id: "AI" } },
+            select: { id: true },
+        });
+
+        const userIds = users.map((u) => u.id);
+
+        await tx.user.updateMany({
+            where: { id: { in: userIds } },
+            data: { isDelivered: false },
+        });
+
+        return userIds;
     });
-    return updated;
+
+    return result;
 };

--- a/src/routes/users.router.js
+++ b/src/routes/users.router.js
@@ -1,10 +1,10 @@
 import { Router } from "express";
-import { 
-    handleCheckOwnId, 
-    handleModifyUserInfo, 
-    handleInquiry, 
-    handleViewNotification, 
-    handleViewMyPage 
+import {
+    handleCheckOwnId,
+    handleModifyUserInfo,
+    handleInquiry,
+    handleViewNotification,
+    handleViewMyPage,
 } from "../controllers/users.controller.js";
 import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
 
@@ -14,7 +14,6 @@ router.get("/check-ownId", authenticateAccessToken, handleCheckOwnId);
 router.patch("/me/profiles", authenticateAccessToken, handleModifyUserInfo);
 router.get("/me/notification", authenticateAccessToken, handleViewNotification);
 router.post("/inquiry", handleInquiry);
-router.get("/me/notification", authenticateAccessToken, handleViewNotification);
 router.get("/:ownId", authenticateAccessToken, handleViewMyPage);
 
 export default router;

--- a/src/services/recoms.service.js
+++ b/src/services/recoms.service.js
@@ -109,10 +109,10 @@ export const addRecoms = async (data, userId) => {
     const newUserSongData = await createUserRecomsSong(data, userId, recomsSong);
     const now = new Date();
     const tomorrow = new Date(now);
-    tomorrow.setHours(24, 0, 0, 0);  // 오늘 자정(내일 0시)으로 설정
+    tomorrow.setHours(24, 0, 0, 0); // 오늘 자정(내일 0시)으로 설정
 
-    const expireAt = tomorrow.getTime(); 
-    await redisClient.set(`userRecomsSongData:user:${userId}`, JSON.stringify(data) , { PXAT: expireAt });
+    const expireAt = tomorrow.getTime();
+    await redisClient.set(`userRecomsSongData:user:${userId}`, JSON.stringify(newUserSongData), { PXAT: expireAt });
 
     return userRecomsSongResponseDTO(newUserSongData, artists, singData);
 };
@@ -215,6 +215,7 @@ export const listRecomsSong = async (userId) => {
 };
 
 export const sendUserRecoms = async (recomsId, userId) => {
+    await redisClient.del(`userRecomsSongData:user:${userId}`);
     let update = await updateReceiver(recomsId, userId);
     if (!update) {
         throw new RecommendationNotFoundError("userRecomsSong 테이블에 데이터가 생성되지 않았습니다.");
@@ -222,6 +223,7 @@ export const sendUserRecoms = async (recomsId, userId) => {
     console.log(update);
 
     // isDelivered true로 변경
+    await redisClient.sRem("user:isDeliveredFalse", userId); // redis set에서 데이터 제거
     const isDelivered = await updateIsDeliveredToTrue(userId);
     if (!isDelivered) {
         throw new NoModifyDataError("userId가 잘못되었습니다. isDelivered가 변경되지 않았습니다.");
@@ -261,6 +263,7 @@ export const sendAIRecoms = async (userId) => {
     console.log("ai가 userRecomsSong에 생성한 데이터: ", newUserSongData);
 
     // isDelivered true로 변경
+    await redisClient.sRem("user:isDeliveredFalse", userId); // redis set에서 데이터 제거
     const isDelivered = await updateIsDeliveredToTrue(userId);
     if (!isDelivered) {
         throw new NoModifyDataError("userId가 잘못되었습니다. isDelivered가 변경되지 않았습니다.");


### PR DESCRIPTION
## 이슈번호 #106

### 📌 작업한 내용  
### 추천 곡 자동 발신 과정에 redis 캐시 적용
- user 테이블에서 isDelivered 컬럼만 사용하므로 key-value 식의 캐시로 저장하지 않고 Redis SET으로 저장 -> user의 id만 저장해서 더 빠르게 조회 가능
- 자정에 user 테이블의 isDelivered 컬럼을 false로 초기화할 때 이전의 user:isDeliveredFalse SET의 값을 지우고 사용자들을 SET에 새로 추가
- 곡을 받는 사용자는 user:isDeliveredFalse SET에서 제거
- userRecomsSongData 캐시를 조회하여 추천 곡을 발신하고 수신자가 지정되면 캐시에서 삭제
- 추천 곡 자동 발신 과정에 캐시가 사용되므로 데이터를 조회하는 DB 함수는 삭제함

---


### 🔍 참고 사항  
- 지금은 추천 곡 자동 발신 과정에만 userRecomsSongData 캐시를 사용하는데 추후에 오늘 받은/보낸 곡을 조회할 때도 캐시를 사용하는 것으로 리팩토링하면 좋을 것 같습니다.
- 아래 징니 코드를 두 번째 코드처럼 바꾸었는데 문제 있으면 코멘트 달아주세요!
`await redisClient.set(userRecomsSongData:user:${userId}, JSON.stringify(newUserSongData) , { PXAT: expireAt });
`
`await redisClient.set(userRecomsSongData:user:${userId}, JSON.stringify(data) , { PXAT: expireAt });
`
- 푸시 알림 토큰 캐시는 알림 기능을 구현하면서 적용하려고 합니다.
---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 

---

### 🔗 관련 이슈  
- redis 캐시 함수와 스프레드 연산자(...)를 함께 사용하면 스프레드 연산자가 적용되지 않고 배열의 첫 번째 인자만 반환이 되는 문제가 있었는데 원인이 뭔지 발견하지 못했습니다... 따라서 스프레드 연산자 대신 for문을 사용하는 것으로 코드를 작성했습니다.

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
