### PR TITLE
[FEAT} 즐겨찾기한 아티스트 목록 조회 API

### DIFF
--- a/src/controllers/artists.controller.js
+++ b/src/controllers/artists.controller.js
@@ -1,5 +1,10 @@
 import { StatusCodes } from "http-status-codes";
-import { viewRecomArtists, postLikedArtists, viewArtistsChannel } from "../services/artists.service.js";
+import { 
+  viewRecomArtists, 
+  postLikedArtists, 
+  viewArtistsChannel,
+  viewLikedArtists 
+} from "../services/artists.service.js";
 
 export const handleViewRecomArtists = async (req, res, next) => {
     /*
@@ -110,6 +115,30 @@ export const handleViewArtists = async (req, res, next) => {
     try {
         const channel = await viewArtistsChannel(req.user.id, req.params.artistId);
         res.status(StatusCodes.OK).success(channel);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const handleViewListLikedArtists = async (req, res, next) => {
+    /*
+    #swagger.summary = '즐겨찾기한 아티스트 목록 조회하기';
+
+    #swagger.security = [{
+        bearerAuth: []
+    }]
+    
+    #swagger.responses[200] = {
+      $ref: "#/components/responses/Success"
+    };
+    
+    #swagger.responses[401] = {
+      $ref: "#/components/responses/TokenError"
+    };
+  */
+    try {
+        const liked = await viewLikedArtists(req.user.id);
+        res.status(StatusCodes.OK).success(liked);
     } catch (err) {
         next(err);
     }

--- a/src/dtos/artists.dto.js
+++ b/src/dtos/artists.dto.js
@@ -44,3 +44,14 @@ export const channelResponseDTO = (data) => {
         }
     };
 };
+
+export const likedArtistsListResponseDTO = (data) => {
+    return {
+        artists: data.map((a) => ({
+            id: a.id,
+            name: a.name,
+            imgUrl: a.imgUrl,
+            isliked: true
+        }))
+    };
+};

--- a/src/routes/artists.router.js
+++ b/src/routes/artists.router.js
@@ -1,5 +1,10 @@
 import { Router } from "express";
-import { handleViewRecomArtists, handlePostLikedArtists, handleViewArtists } from "../controllers/artists.controller.js";
+import { 
+    handleViewRecomArtists, 
+    handlePostLikedArtists, 
+    handleViewArtists,
+    handleViewListLikedArtists 
+} from "../controllers/artists.controller.js";
 import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
 
 const router = Router();
@@ -7,5 +12,6 @@ const router = Router();
 router.get("/recommended", handleViewRecomArtists);
 router.post("/liked", authenticateAccessToken, handlePostLikedArtists);
 router.get("/:artistId", authenticateAccessToken, handleViewArtists);
+router.get("/liked/list", authenticateAccessToken, handleViewListLikedArtists);
 
 export default router;

--- a/src/services/artists.service.js
+++ b/src/services/artists.service.js
@@ -11,13 +11,15 @@ import {
     updateInactiveStatusToFalse,
     updateInactiveStatusToTrue,
     getArtistsChannel,
+    getMyLikedArtists
 } from "../repositories/artists.repository.js";
 import { getArtistsRandomly } from "./musicAPI.service.js";
 import { 
     artistsResponseDTO, 
     recomsArtistsResponseDTO, 
     likedArtistsResponseDTO,
-    channelResponseDTO 
+    channelResponseDTO,
+    likedArtistsListResponseDTO
 } from "../dtos/artists.dto.js";
 
 export const viewRecomArtists = async (sort, cursor) => {
@@ -91,4 +93,10 @@ export const viewArtistsChannel = async (userId, artistId) => {
     const artistsChannel = await getArtistsChannel(userId, artistId);
 
     return channelResponseDTO(artistsChannel);
+};
+
+export const viewLikedArtists = async (userId) => {
+    const likedArtists = await getMyLikedArtists(userId);
+
+    return likedArtistsListResponseDTO(likedArtists);
 };


### PR DESCRIPTION
## 이슈번호 #114 

### 📌 작업한 내용  
유저가 즐겨찾기한 아티스트를 팬 수(즐겨찾기 수)가 많은 순으로 내림차순 정렬하여 최대 6명까지 불러옵니다.

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

---


### 🖼️ 스크린샷  
<img width="508" height="505" alt="image" src="https://github.com/user-attachments/assets/4adf6b01-2b52-472b-af21-9a95177c9e5c" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [X] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
