### PR TITLE
[FIX] 추천 기록 캘린더 receiverId가 null일 경우 로직 추가

### DIFF
--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -192,7 +192,7 @@ export const getCalendarRecomsSong = async (userId, year, month, status) => {
             gte: startDate,
             lt: endDate,
         },
-        ...(status === "recommending" ? { senderId: userId } : { receiverId: userId }),
+        ...(status === "recommending" ? { senderId: userId, receiverId: { not: null } } : { receiverId: userId }),
     };
 
     const calendarsData = await prisma.userRecomsSong.findMany({


### PR DESCRIPTION
## 이슈번호 #117 

### 📌 작업한 내용  
유저가 추천한 곡에 관련한 기록을 불러오는 캘린더를 조회할 경우 아직 전송되지 않은 곡도 기록에 기재가 되어서,
receiverId가 null일 경우에는 불러오지 않도록 수정하였습니다.

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

---


### 🖼️ 스크린샷  
<img width="1151" height="488" alt="image" src="https://github.com/user-attachments/assets/384a9da8-1449-4b9e-9ce1-7cd6e5f84527" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
