### PR TITLE
[FEAT] 회원탈퇴 API 구현

### DIFF
--- a/src/components/components.js
+++ b/src/components/components.js
@@ -471,5 +471,26 @@ export default {
                 },
             },
         },
+        AlreadyInactiveError: {
+            description: "이미 비활성화인 상태의 유저를 회원탈퇴 시킬 때",
+            content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            success: { type: "boolean", example: false },
+                            data: { type: "object", nullable: true },
+                            error: {
+                                type: "object",
+                                properties: {
+                                    code: { type: "string", example: "R200" },
+                                    message: { type: "string", example: "이미 비활성화 상태인 사용자입니다." },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
     },
 };

--- a/src/configs/auth.config.js
+++ b/src/configs/auth.config.js
@@ -1,5 +1,6 @@
 import jwt from "jsonwebtoken";
 import jwksClient from "jwks-rsa"; 
+import { TokenError } from "../errors.js";
 
 export const getKakaoUser = async (idToken) => {
   const client = jwksClient({
@@ -7,6 +8,9 @@ export const getKakaoUser = async (idToken) => {
   });
 
   const decodedHeader = jwt.decode(idToken, { complete: true });
+  if (!decodedHeader || !decodedHeader.header) {
+    throw new TokenError("잘못된 토큰 형식입니다.");
+  }
   const kid = decodedHeader.header.kid;
 
   const key = await client.getSigningKey(kid);

--- a/src/dtos/users.dto.js
+++ b/src/dtos/users.dto.js
@@ -28,3 +28,13 @@ export const getMyPageResponseDTO = (data) => {
         bio: data.bio
     };
 };
+
+export const withdrawResponseDTO = (data) => {
+    const kstDate = data.inactiveAt!==null ? new Date(data.inactiveAt.getTime() + 9 * 60 * 60 * 1000): null;
+    
+    return {
+        id: data.id,
+        inactiveAt: kstDate,
+        inactiveStatus: data.inactiveStatus
+    }
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -21,6 +21,17 @@ export class InvalidEmailTypeError extends Error {
     }
 }
 
+export class AlreadyInactiveError extends Error {
+    errorcode = "U1200";
+    statusCode = 409;
+
+    constructor(reason, data){
+        super(reason);
+        this.reason = reason;
+        this.data = data
+    }
+}
+
 export class NotSupportedSocialLoginError extends Error {
     errorCode = "U1300";
     statusCode = 401;

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -89,3 +89,13 @@ export const findUserByToken = async (id) => {
         where: { id: id } 
     });
 }
+
+export const modifyUserStatus = async (id, status) => {
+    return await prisma.user.update({
+        where: {id: id},
+        data: {
+            inactiveStatus: status,
+            inactiveAt: status ? new Date() : null // "YYYY-MM-DD"
+        }
+    })
+}

--- a/src/routes/oauth.router.js
+++ b/src/routes/oauth.router.js
@@ -1,10 +1,11 @@
 import { Router } from "express";
-import { handleKakaoLogin, handleKakaoLogout, handleRefreshAccessToken } from "../controllers/oauth.controllers.js"
+import { handleKakaoLogin, handleKakaoLogout, handleRefreshAccessToken, handleWithdraw } from "../controllers/oauth.controllers.js"
 
 const router = Router();
 
 router.post("/callback/kakao", handleKakaoLogin);
 router.patch("/refresh/token", handleRefreshAccessToken);
 router.post("/logout", handleKakaoLogout);
+router.post("/withdraw", handleWithdraw);
 
 export default router;


### PR DESCRIPTION
## 이슈번호 #124 <!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
이 PR에서 변경된 내용을 간략히 작성해주세요.
- 회원탈퇴 기능 구현

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.
- 회원 탈퇴 시 inActiveStatus를 true로 바꿈
  - 기존 구현시 Kakao의 unlink 함수를 이용하기 때문에 데이터를 delete 하는 것이 더 적합하다는 판단을 했으나, delete 하게 되면 추천 기록과 같이 탈퇴한 사용자가 보여야 하는 부분에 오류가 발생하게 된다. 따라서, soft delete를 사용하는 것이 적합하다고 판단

- 추후, 로그인 로직 수정 예정
  - DB에 사용자의 이름, 이메일 일치하는 데이터 있는지 확인 후, 
    - 있으면, 탈퇴 후 복구 로직
    - 없으면, 신규 사용자 로직

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 
<img width="618" height="586" alt="image" src="https://github.com/user-attachments/assets/bb709a80-4b99-4711-8a08-97cdab88749c" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
