### PR TITLE
[FEAT] 게정 복구 로직 추가

### DIFF
--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -14,6 +14,15 @@ export const getUserByOwnId = async (checkingOwnId) => {
     return userData;
 };
 
+export const getUserByEmail = async (userName, userEmail) => {
+    return await prisma.user.findFirst({ 
+        where: { 
+            name: userName,
+            email: userEmail 
+        } 
+    });
+}
+
 export const modifyUser = async (userId, data) => {
     const updatedUser = await prisma.user.update({
         where: { id: userId },
@@ -35,29 +44,28 @@ export const createInquiry = async (userName, userEmail, text) => {
     return newInquiry.id;
 };
 
-export const findOrCreateUser = async (userName, userEmail, type) => {
-    let user = await prisma.user.findFirst({ where: { email: userEmail } });
+export const createUser = async (userName, userEmail, type) => {
+    user = await prisma.user.create({
+        data: {
+            name: userName,
+            email: userEmail,
+            socialType: type,
+        },
+    });
+    return user;
+}
 
-    if (!user) {
-        user = await prisma.user.create({
+export const updateUserLogin = async (id, userName, userEmail, type) => {
+    const user = await prisma.user.update({
+            where: { id: id},
             data: {
                 name: userName,
                 email: userEmail,
                 socialType: type,
             },
-        });
-    } else {
-        user = await prisma.user.update({
-            where: { id: user.id },
-            data: {
-                name: userName,
-                email: userEmail,
-                socialType: type,
-            },
-        });
-    }
-    return { id: user.id, name: user.name, email: user.email, socialType: user.socialType };
-};
+    });
+    return user;
+}
 
 export const getNotification = async (userId, decoded, limit) => {
     const notification = await prisma.notification.findMany({


### PR DESCRIPTION
## 이슈번호 #126<!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
이 PR에서 변경된 내용을 간략히 작성해주세요.
- 계정 복구 로직 추가했습니다
---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.
[복구 로직]
로그인 시 아이디 토큰으로 카카오에서 이메일, 이름 불러오기
1. 이메일, 이름으로 유저 아이디 찾기
2. 아이디 존재하고, inactiveStatus 가 true -> 게정 복구 (inactiveStatus = false)
3.  아이디 존재하고, inactiveStatus 가 falase -> 정보 업데이트
4. 아이디 존재하지 않으면, 신규 가입자 -> 유저 생성

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 
<img width="508" height="690" alt="image" src="https://github.com/user-attachments/assets/75d60c57-0f4e-4530-9d56-feef8e3b8ffc" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
