### PR TITLE
[FEAT] 알림 설정 API 구현

### DIFF
--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -1,5 +1,11 @@
 import { StatusCodes } from "http-status-codes";
-import { checkOwnId, modifyUserInfo, viewNotification, viewMyPage } from "../services/users.service.js";
+import {
+    checkOwnId,
+    modifyUserInfo,
+    viewNotification,
+    viewMyPage,
+    setNotification,
+} from "../services/users.service.js";
 import { sendEmail } from "../services/nodemailer.service.js";
 import { userInfoRequestDTO } from "../dtos/users.dto.js";
 
@@ -177,6 +183,53 @@ export const handleViewMyPage = async (req, res, next) => {
     try {
         const mypage = await viewMyPage(req.user.id, req.params.ownId);
         res.status(StatusCodes.OK).success(mypage);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const handleSetNotification = async (req, res, next) => {
+    /*
+    #swagger.summary = '알림 설정 API'
+
+    #swagger.security = [{
+        bearerAuth: []
+    }]
+
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              recomsSent: { type: "boolean", example: true },
+              recomsReceived: { type: "boolean", example: true },
+              commentArrived: { type: "boolean", example: true },
+              notRecoms: { type: "boolean", example: true },
+              announcement: { type: "boolean", example: true }
+            },
+          }
+        }
+      }
+    };
+
+    #swagger.responses[200] = {
+        $ref: "#/components/responses/Success"
+    };
+
+    #swagger.responses[400] = {
+        $ref: "#/components/responses/RequestBodyError"
+    };
+
+    #swagger.responses[401] = {
+        $ref: "#/components/responses/TokenError"
+    };
+    */
+
+    try {
+        const setting = await setNotification(req.user.id, req.body);
+        res.status(StatusCodes.OK).success(setting);
     } catch (err) {
         next(err);
     }

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -85,17 +85,24 @@ export const getNotification = async (userId, decoded, limit) => {
 };
 
 export const findUserByToken = async (id) => {
-    return await prisma.user.findUnique({ 
-        where: { id: id } 
+    return await prisma.user.findUnique({
+        where: { id: id },
     });
-}
+};
 
 export const modifyUserStatus = async (id, status) => {
     return await prisma.user.update({
-        where: {id: id},
+        where: { id: id },
         data: {
             inactiveStatus: status,
-            inactiveAt: status ? new Date() : null // "YYYY-MM-DD"
-        }
-    })
-}
+            inactiveAt: status ? new Date() : null, // "YYYY-MM-DD"
+        },
+    });
+};
+
+export const updateNotificationSetting = async (userId, body) => {
+    return await prisma.notificationType.update({
+        where: { userId: userId },
+        data: body,
+    });
+};

--- a/src/routes/users.router.js
+++ b/src/routes/users.router.js
@@ -5,6 +5,7 @@ import {
     handleInquiry,
     handleViewNotification,
     handleViewMyPage,
+    handleSetNotification,
 } from "../controllers/users.controller.js";
 import { authenticateAccessToken } from "../middlewares/authenticate.jwt.js";
 
@@ -15,5 +16,6 @@ router.patch("/me/profiles", authenticateAccessToken, handleModifyUserInfo);
 router.get("/me/notification", authenticateAccessToken, handleViewNotification);
 router.post("/inquiry", handleInquiry);
 router.get("/:ownId", authenticateAccessToken, handleViewMyPage);
+router.patch("/notification-settings", authenticateAccessToken, handleSetNotification);
 
 export default router;

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -6,8 +6,15 @@ import {
     CursorError,
     AuthError,
     NotFoundOwnIdError,
+    RequestBodyError,
 } from "../errors.js";
-import { getUserById, getUserByOwnId, modifyUser, getNotification } from "../repositories/users.repository.js";
+import {
+    getUserById,
+    getUserByOwnId,
+    modifyUser,
+    getNotification,
+    updateNotificationSetting,
+} from "../repositories/users.repository.js";
 import { notificationResponseDTO, getMyPageResponseDTO } from "../dtos/users.dto.js";
 
 export const checkOwnId = async (userOwnId) => {
@@ -123,4 +130,20 @@ export const viewMyPage = async (userId, ownId) => {
     } else {
         return getMyPageResponseDTO(other);
     }
+};
+
+export const setNotification = async (userId, body) => {
+    const allowedKeys = ["recomsSent", "recomsReceived", "commentArrived", "notRecoms", "announcement"];
+
+    for (const key in body) {
+        if (!allowedKeys.includes(key)) {
+            throw new RequestBodyError("유효하지 않은 request body 형식입니다.");
+        }
+
+        if (typeof body[key] !== "boolean") {
+            throw new RequestBodyError("유효하지 않은 request body 형식입니다.");
+        }
+    }
+    const updated = await updateNotificationSetting(userId, body);
+    return updated;
 };


### PR DESCRIPTION
## 이슈번호 #128

### 📌 작업한 내용  
알림 설정 API 구현
- 사용자가 수신할 알림의 타입을 설정할 수 있다.

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

---


### 🖼️ 스크린샷  
<img width="839" height="304" alt="image" src="https://github.com/user-attachments/assets/d8ef6985-cdbd-45e0-a435-7d0f32a1b77d" />

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
