### PR TITLE
[FIX] 추천 리스트 조회 시 아티스트 아이디 반환

### DIFF
--- a/src/dtos/recoms.dto.js
+++ b/src/dtos/recoms.dto.js
@@ -157,6 +157,7 @@ export const listRecomsResponseDTO = (data, userId) => {
 
         const dto = {
             title: recom.recomsSong.title,
+            artistId: recom.recomsSong.artistId,
             artistName: recom.recomsSong.artistName,
             imageUrl: recom.recomsSong.imgUrl,
             comment: recom.comment,

--- a/src/repositories/artists.repository.js
+++ b/src/repositories/artists.repository.js
@@ -13,6 +13,16 @@ export const createArtist = async (artistData) => {
     return created;
 };
 
+export const getArtistByName = async (artistName) => {
+    console.log(artistName);
+    const artist = await prisma.artist.findFirst({
+        where: {
+            name: artistName
+        }
+    })
+    return artist.id;
+}
+
 export const getArtistById = async (artistId) => {
     return await prisma.artist.findUnique({
         where: {

--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -303,7 +303,7 @@ export const createUserRecomsSongByAI = async (receiverId, comment, recomsSong) 
     return created;
 };
 
-export const getListRecomsSong = async (userId) => {
+export const getListRecomsSong = async (userId, artistId) => {
     const listData = await prisma.userRecomsSong.findMany({
         where: {
             OR: [{ senderId: userId }, { receiverId: userId }],

--- a/src/services/musicAPI.service.js
+++ b/src/services/musicAPI.service.js
@@ -95,10 +95,13 @@ export async function getArtistInfo(artistName) {
             },
         });
 
+        console.log(spotifyData.data.artists.items[0]);
+        const artistImgUrl = spotifyData?.data?.artists?.items?.[0]?.images?.[0]?.url ?? null;
+
         return {
             id: spotifyData.data.artists.items[0].id,
             name: spotifyData.data.artists.items[0].name,
-            imgUrl: spotifyData.data.artists.items[0].images[0].url,
+            imgUrl: artistImgUrl,
         };
     } catch (err) {
         console.error("Spotify API 요청 실패:", err.response?.data || err.message);


### PR DESCRIPTION
## 이슈번호 #146 <!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
이 PR에서 변경된 내용을 간략히 작성해주세요.

아티스트를 아이디로 조회함에 따라 추천 리스트 전송 시 아티스트 아이디를 추가로 전송하도록 구현

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

- recomsSong에 있는 아티스트 이름으로 아티스트 테이블을 조회하면, recomsSong에 있는 아티스트 데이터는 iTunes 데이터이고, 아티스트 테이블에 있는 데이터는 Spotify 데이터이기 때문에 데이터가 달라 조회불가하다. 
-> 추천 리스트를 가져온 후, 모든 데이터에서 artistName을 불러와 getSongInfo 함수를 이용하여 Spotify API에서 반복해서 id를 가져온다 .....
-> 병렬로 처리해 시간을 단축시켰다.

더 효율적인 방법이 있을 것 같지만 아직까진 찾지 못했다.....

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 
<img width="554" height="422" alt="image" src="https://github.com/user-attachments/assets/bdfa0a70-3e9c-43af-93e8-1507c867d674" />


---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
