### PR TITLE
[REFACTOR] 추천 기록 리스트 조회 API 응답에 aritstId 추가

### DIFF
--- a/src/dtos/recoms.dto.js
+++ b/src/dtos/recoms.dto.js
@@ -157,7 +157,7 @@ export const listRecomsResponseDTO = (data, userId) => {
 
         const dto = {
             title: recom.recomsSong.title,
-            artistId: recom.recomsSong.artistId,
+            artistIds: recom.recomsSong.artistIds,
             artistName: recom.recomsSong.artistName,
             imageUrl: recom.recomsSong.imgUrl,
             comment: recom.comment,

--- a/src/repositories/recoms.repository.js
+++ b/src/repositories/recoms.repository.js
@@ -304,7 +304,7 @@ export const createUserRecomsSongByAI = async (receiverId, comment, recomsSong) 
     return created;
 };
 
-export const getListRecomsSong = async (userId, artistId) => {
+export const getListRecomsSong = async (userId) => {
     const listData = await prisma.userRecomsSong.findMany({
         where: {
             OR: [{ senderId: userId }, { receiverId: userId }],
@@ -317,6 +317,7 @@ export const getListRecomsSong = async (userId, artistId) => {
             recomsSong: {
                 select: {
                     title: true,
+                    artistIds: true,
                     artistName: true,
                     imgUrl: true,
                 },

--- a/src/services/recoms.service.js
+++ b/src/services/recoms.service.js
@@ -242,17 +242,7 @@ export const sendReplies = async (recomsId, userId, content) => {
 export const listRecomsSong = async (userId) => {
     const data = await getListRecomsSong(userId);
 
-    const promises = data.map(async (recoms) => {
-        const artist = await getArtistInfo(recoms.recomsSong.artistName);
-        recoms.recomsSong.artistId = artist?.id ?? null; // 안전하게 null 처리
-        return recoms;
-    });
-
-    // 병렬로 처리 (병렬로 처리 안 하면 데이터 하나 당 외부 API 이용하기 때문에 오래걸림)
-    const updatedData = await Promise.all(promises);
-    console.log(updatedData);
-
-    return listRecomsResponseDTO(updatedData, userId);
+    return listRecomsResponseDTO(data, userId);
 };
 
 export const sendUserRecoms = async (recomsId, receiverId, senderId) => {


### PR DESCRIPTION
## 이슈번호 #152 

### 📌 작업한 내용  
artistId를 recomsSong에서 직접적으로 가져왔다.

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

---


### 🖼️ 스크린샷  
<img width="881" height="317" alt="image" src="https://github.com/user-attachments/assets/c3b246a8-5fcd-4367-a504-ee3da5be3fcb" />

---

### 🔗 관련 이슈  
현재 DB에 비어있는 artistId가 너무 많은데 기존에 있던 데이터를 모두 지우고 새롭게 추천 곡을 집어넣어놓는 것이
데모데이 때나 프론트 작업 결과 확인할 때 용이할 것 같은데 팀원들은 어떻게 생각하시나요?

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
