### PR TITLE
[REFACTOR] 프론트로부터 inactive 값을 받아오도록 수정

### DIFF
--- a/src/controllers/artists.controller.js
+++ b/src/controllers/artists.controller.js
@@ -68,6 +68,7 @@ export const handlePostLikedArtists = async (req, res, next) => {
                         id: { type: "string" },
                         name: { type: "string" },
                         imgUrl: { type: "string" },
+                        inactive: { type: "boolean" }
                     }
                 }
             }

--- a/src/services/artists.service.js
+++ b/src/services/artists.service.js
@@ -1,9 +1,4 @@
-import { 
-    QueryParamError, 
-    CursorError, 
-    NotFoundArtistsError, 
-    RequestBodyError,
-} from "../errors.js";
+import { QueryParamError, CursorError, NotFoundArtistsError, RequestBodyError } from "../errors.js";
 import {
     getArtistsByPopularity,
     createLikedArtist,
@@ -11,15 +6,15 @@ import {
     updateInactiveStatusToFalse,
     updateInactiveStatusToTrue,
     getArtistsChannel,
-    getMyLikedArtists
+    getMyLikedArtists,
 } from "../repositories/artists.repository.js";
 import { getArtistsRandomly } from "./musicAPI.service.js";
-import { 
-    artistsResponseDTO, 
-    recomsArtistsResponseDTO, 
+import {
+    artistsResponseDTO,
+    recomsArtistsResponseDTO,
     likedArtistsResponseDTO,
     channelResponseDTO,
-    likedArtistsListResponseDTO
+    likedArtistsListResponseDTO,
 } from "../dtos/artists.dto.js";
 
 export const viewRecomArtists = async (sort, cursor) => {
@@ -71,17 +66,18 @@ export const postLikedArtists = async (body, userId) => {
         typeof body !== "object" ||
         typeof body.id !== "string" ||
         typeof body.name !== "string" ||
-        typeof body.imgUrl !== "string"
+        typeof body.imgUrl !== "string" ||
+        typeof body.inactive !== "boolean"
     ) {
         throw new RequestBodyError("잘못된 request body 형식입니다.");
     }
     let updated;
     const likedArtist = await getUserlikedArtist(body.id, userId);
     if (likedArtist) {
-        if (likedArtist.inactiveStatus) {
-            updated = await updateInactiveStatusToFalse(likedArtist.id);
-        } else {
+        if (body.inactive) {
             updated = await updateInactiveStatusToTrue(likedArtist.id);
+        } else {
+            updated = await updateInactiveStatusToFalse(likedArtist.id);
         }
     } else {
         updated = await createLikedArtist(body, userId);


### PR DESCRIPTION
## 이슈번호 #167

### 📌 작업한 내용  
- 아티스트 즐겨찾기 API의 request body에 inactive 값을 추가해서 프론트가 즐겨찾기 해제를 명시적으로 할 수 있게끔 수정하였습니다. 

---


### 🔍 참고 사항  
리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요.

---


### 🖼️ 스크린샷  
응답 객체 변경 사항이 있다면, 스웨거나 관련 스크린샷을 첨부해주세요. 

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
