### PR TITLE
[FIX] redisClient 오타 및 UTC timezone 맞추기

### DIFF
--- a/src/cron/scheduler.js
+++ b/src/cron/scheduler.js
@@ -134,10 +134,11 @@ export const resetIsDeliveredScheduler = async () => {
         "0 0 * * *",
         async () => {
             try {
+                await redisClient.del("user:isSentSong");
+                await redisClient.del("*userRecomsSongData*"); // TTL이 반영되지 않는 경우 대비
                 const updated = await updateIsDeliveredToFalse();
                 console.log("업데이트 된 행의 개수: ", updated);
                 console.log(new Date());
-                await redis.del("user:isSentSong");
             } catch (err) {
                 console.error(`resetIsDeliveredScheduler error: ${err}`);
                 throw new SchedulerError(
@@ -178,10 +179,11 @@ export const notReadScheduler = async () => {
         async () => {
             try {
                 const isReadFalse = await getIsReadFalse();
+                console.log(isReadFalse);
                 if (!isReadFalse?.length) return;
-
+                console.log(isReadFalse);
                 const users = isReadFalse.map((item) => item.receiverId);
-
+                console.log("users: ", users);
                 const allowedNotifications = await getAllowedNotifications(users);
                 const allowedMap = new Map(allowedNotifications.map((r) => [r.userId, r]));
 

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -143,6 +143,22 @@ export const modifyUserInfo = async (userId, data) => {
         if (!timeRegex.test(updates.recomsTime)) {
             throw new InvalidRecomsTimeError("추천 시간은 HHmm 형식이어야 합니다.");
         }
+
+        // UTC 변환 후 DB 저장
+        const hours = parseInt(updates.recomsTime.slice(0, 2), 10);
+        const minutes = parseInt(updates.recomsTime.slice(2), 10);
+
+        // KST 기준 Date 객체 생성
+        const kstDate = new Date();
+        kstDate.setHours(hours, minutes, 0, 0);
+
+        // UTC 기준으로 변환
+        const utcHours = kstDate.getUTCHours().toString().padStart(2, "0");
+        const utcMinutes = kstDate.getUTCMinutes().toString().padStart(2, "0");
+
+        // DB 저장용 UTC 시간 문자열
+        updates.recomsTime = `${utcHours}${utcMinutes}`;
+        console.log(updates.recomsTime);
     }
 
     /// 날짜 형식 검사: YYYY-MM-DD

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -148,15 +148,12 @@ export const modifyUserInfo = async (userId, data) => {
         const hours = parseInt(updates.recomsTime.slice(0, 2), 10);
         const minutes = parseInt(updates.recomsTime.slice(2), 10);
 
-        // KST 기준 Date 객체 생성
         const kstDate = new Date();
         kstDate.setHours(hours, minutes, 0, 0);
 
-        // UTC 기준으로 변환
         const utcHours = kstDate.getUTCHours().toString().padStart(2, "0");
         const utcMinutes = kstDate.getUTCMinutes().toString().padStart(2, "0");
 
-        // DB 저장용 UTC 시간 문자열
         updates.recomsTime = `${utcHours}${utcMinutes}`;
         console.log(updates.recomsTime);
     }


### PR DESCRIPTION
## 이슈번호 #172

### 📌 작업한 내용  
1. user:isSentSong 캐시 삭제 오류 -> redis 오타를 redisClient로 수정
2. 사용자가 추천 받기를 원하는 시간(recomsTime)을 UTC 형식으로 변경
- e.g. 추천 희망 시간이 KST 12시(정오)면 DB에는 "0300"으로 저장됨
3. 오전 9시(UTC 기준 전날 15:00~자정) 이전에 생성된 곡은 receiver가 지정돼도 수신 곡을 조회할 때 조회되지 않음
- 서버와 로컬의 타임존이 맞지 않아서 발생하는 문제
- startOfDay(), endOfDay()는 로컬 타임존을 반환하는데, DB에서 UTC 기준으로 저장된 데이터도 잘 가져오길래 문제 없는 줄 알았으나 EC2 (UTC)에서 돌릴 시 로직 오류 발생

---


### 🔍 참고 사항  
- 추천 받기를 원하는 시간이 default 09:00인데, 로직을 변경함에 따라 실제 추천을 받는 시간이 18:00가 됩니다 ... default값을 변경하거나 기본 추천 시간을 18:00로 변경해야 할 것 같습니다.

---


### 🖼️ 스크린샷  
- 15:00로 지정했을 때 DB에는 0600으로 저장됨 (kkangda33)
<img width="780" height="275" alt="스크린샷 2025-08-21 164551" src="https://github.com/user-attachments/assets/a89c4566-449d-4bcc-8dec-59a8bad01261" />
<img width="368" height="261" alt="스크린샷 2025-08-21 164544" src="https://github.com/user-attachments/assets/12f8c7e2-891f-4cde-8fd7-6d631d086e21" />

- 로컬에서 서버 시간을 UTC로 바꾸고 코드 돌린 결과 전날 15:00~자정에 저장된 데이터도 오늘 생성된 데이터로 잘 조회가 됨
<img width="1608" height="482" alt="image" src="https://github.com/user-attachments/assets/57500be2-f8a9-4365-a5a7-4fa1be07f446" />

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
